### PR TITLE
[bug] added dev deps and fixed example file name(create-faas-app)

### DIFF
--- a/packages/create-faas-app/src/action.ts
+++ b/packages/create-faas-app/src/action.ts
@@ -1,14 +1,14 @@
-import { Command } from 'commander';
-import { prompt } from 'enquirer';
-import { mkdirSync, writeFileSync, existsSync } from 'fs';
-import { join } from 'path';
-import { execSync } from 'child_process';
+import {Command} from 'commander';
+import {prompt} from 'enquirer';
+import {mkdirSync, writeFileSync, existsSync} from 'fs';
+import {join} from 'path';
+import {execSync} from 'child_process';
 
 const Provider = ['tencentcloud', null];
 const Region = ['ap-beijing', 'ap-shanghai', 'ap-guangzhou', 'ap-hongkong'];
 
 const Validator = {
-  name (input: string) {
+  name(input: string) {
     const match = /^[a-z0-9-_]+$/i.test(input) ? true : 'Must be a-z, 0-9 or -_';
     if (match !== true) return match;
     if (existsSync(input)) {
@@ -16,24 +16,24 @@ const Validator = {
     }
     return true;
   },
-  provider (input: string | null) {
+  provider(input: string | null) {
     return Provider.includes(input) ? true : 'Unknow provider';
   },
-  region (input: string) {
+  region(input: string) {
     return Region.includes(input) ? true : 'Unknown region';
   },
-  appId (input: string) {
+  appId(input: string) {
     return /^[0-9]+$/.test(input) ? true : 'Wrong format';
   },
-  secretId (input: string) {
+  secretId(input: string) {
     return /^[a-zA-Z0-9]+$/.test(input) ? true : 'Wrong format';
   },
-  secretKey (input: string) {
+  secretKey(input: string) {
     return /^[a-zA-Z0-9]+$/.test(input) ? true : 'Wrong format';
   }
 };
 
-export async function action (options?: {
+export async function action(options?: {
   name?: string;
   region?: string;
   appId?: string;
@@ -57,7 +57,7 @@ export async function action (options?: {
       name: 'value',
       message: 'Project name',
       validate: Validator.name
-    }).then((res: { value: string }) => res.value);
+    }).then((res: {value: string}) => res.value);
   }
 
   answers.provider = await prompt({
@@ -74,7 +74,7 @@ export async function action (options?: {
         message: '腾讯云'
       },
     ]
-  }).then((res: { value: string }) => res.value);
+  }).then((res: {value: string}) => res.value);
 
   if (answers.provider === 'tencentcloud') {
     if (!answers.region || Validator.region(answers.region) !== true) {
@@ -84,7 +84,7 @@ export async function action (options?: {
         message: 'Region',
         choices: Region.concat([]), // choices 会修改 Region 对象，因此克隆一份
         validate: Validator.region
-      }).then((res: { value: string }) => res.value);
+      }).then((res: {value: string}) => res.value);
     }
 
     if (!answers.appId || Validator.appId(answers.appId) !== true) {
@@ -93,7 +93,7 @@ export async function action (options?: {
         name: 'value',
         message: 'appId (from https://console.cloud.tencent.com/developer)',
         validate: Validator.appId
-      }).then((res: { value: string }) => res.value);
+      }).then((res: {value: string}) => res.value);
     }
 
     if (!answers.secretId || Validator.secretId(answers.secretId) !== true) {
@@ -102,7 +102,7 @@ export async function action (options?: {
         name: 'value',
         message: 'secretId (from https://console.cloud.tencent.com/cam/capi)',
         validate: Validator.secretId
-      }).then((res: { value: string }) => res.value);
+      }).then((res: {value: string}) => res.value);
     }
 
     if (!answers.secretKey || Validator.secretKey(answers.secretKey) !== true) {
@@ -111,7 +111,7 @@ export async function action (options?: {
         name: 'value',
         message: 'secretKey (from https://console.cloud.tencent.com/cam/capi)',
         validate: Validator.secretKey
-      }).then((res: { value: string }) => res.value);
+      }).then((res: {value: string}) => res.value);
     }
   }
 
@@ -121,7 +121,7 @@ export async function action (options?: {
       name: 'value',
       message: 'Add example files',
       initial: true
-    }).then((res: { value: boolean }) => res.value);
+    }).then((res: {value: boolean}) => res.value);
   }
 
   mkdirSync(answers.name);
@@ -180,6 +180,8 @@ production:`);
     "tmp"
   ],
   "jest": {
+    "ts-jest",
+    "collectCoverage": true,
     "collectCoverageFrom": [
       "**/*.ts"
     ],
@@ -187,10 +189,6 @@ production:`);
     "modulePathIgnorePatterns": [
       "/tmp/"
     ]
-  },
-  "devDependencies": {
-    "@babel/preset-env": "^7.10.4",
-    "@babel/preset-typescript": "^7.10.4"
   }
 }`);
 
@@ -216,7 +214,7 @@ tmp/
   "files.trimFinalNewlines": true
 }`);
 
-  execSync(`yarn --cwd ${answers.name} install`, { stdio: 'inherit' });
+  execSync(`yarn --cwd ${answers.name} install`, {stdio: 'inherit'});
 
   if (answers.example) {
     writeFileSync(join(answers.name, 'index.func.ts'),
@@ -244,7 +242,7 @@ describe('hello', function () {
   });
 });`);
 
-    execSync(`yarn --cwd ${answers.name} jest`, { stdio: 'inherit' });
+    execSync(`yarn --cwd ${answers.name} jest`, {stdio: 'inherit'});
   }
 }
 

--- a/packages/create-faas-app/src/action.ts
+++ b/packages/create-faas-app/src/action.ts
@@ -158,19 +158,6 @@ production:`);
     "faasjs": "beta",
     "@faasjs/eslint-config-recommended": "beta"
   },
-  "babel": {
-    "presets": [
-      [
-        "@babel/preset-env",
-        {
-          "targets": {
-            "node": 8
-          }
-        }
-      ],
-      "@babel/preset-typescript"
-    ]
-  },
   "eslintConfig": {
     "extends": [
       "@faasjs/recommended"

--- a/packages/create-faas-app/src/action.ts
+++ b/packages/create-faas-app/src/action.ts
@@ -187,6 +187,10 @@ production:`);
     "modulePathIgnorePatterns": [
       "/tmp/"
     ]
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.10.4",
+    "@babel/preset-typescript": "^7.10.4"
   }
 }`);
 
@@ -215,7 +219,7 @@ tmp/
   execSync(`yarn --cwd ${answers.name} install`, { stdio: 'inherit' });
 
   if (answers.example) {
-    writeFileSync(join(answers.name, 'hello.func.ts'),
+    writeFileSync(join(answers.name, 'index.func.ts'),
       `import { Func } from '@faasjs/func';
 import { Http } from '@faasjs/http';
 
@@ -227,12 +231,12 @@ export default new Func({
 });`);
 
     mkdirSync(join(answers.name, '__tests__'));
-    writeFileSync(join(answers.name, '__tests__', 'hello.test.ts'),
+    writeFileSync(join(answers.name, '__tests__', 'index.test.ts'),
       `import { FuncWarpper } from '@faasjs/test';
 
 describe('hello', function () {
   test('should work', async function () {
-    const func = new FuncWarpper(require.resolve('../hello.func'));
+    const func = new FuncWarpper(require.resolve('../index.func'));
 
     const res = await func.handler({});
 

--- a/packages/create-faas-app/src/action.ts
+++ b/packages/create-faas-app/src/action.ts
@@ -11,9 +11,9 @@ const Validator = {
   name (input: string) {
     const match = /^[a-z0-9-_]+$/i.test(input) ? true : 'Must be a-z, 0-9 or -_';
     if (match !== true) return match;
-    if (existsSync(input)) 
+    if (existsSync(input)) {
       return `${input} folder exists, please try another name`;
-    
+    }
     return true;
   },
   provider (input: string | null) {
@@ -51,14 +51,14 @@ export async function action (options?: {
     example?: boolean;
   } = Object.assign(options, {});
 
-  if (!options.name || Validator.name(options.name) !== true) 
+  if (!options.name || Validator.name(options.name) !== true) {
     answers.name = await prompt({
       type: 'input',
       name: 'value',
       message: 'Project name',
       validate: Validator.name
-    }).then((res: {value: string}) => res.value);
-  
+    }).then((res: { value: string }) => res.value);
+  }
 
   answers.provider = await prompt({
     type: 'select',
@@ -74,55 +74,55 @@ export async function action (options?: {
         message: '腾讯云'
       },
     ]
-  }).then((res: {value: string}) => res.value);
+  }).then((res: { value: string }) => res.value);
 
   if (answers.provider === 'tencentcloud') {
-    if (!answers.region || Validator.region(answers.region) !== true) 
+    if (!answers.region || Validator.region(answers.region) !== true) {
       answers.region = await prompt({
         type: 'select',
         name: 'value',
         message: 'Region',
         choices: Region.concat([]), // choices 会修改 Region 对象，因此克隆一份
         validate: Validator.region
-      }).then((res: {value: string}) => res.value);
-    
+      }).then((res: { value: string }) => res.value);
+    }
 
-    if (!answers.appId || Validator.appId(answers.appId) !== true) 
+    if (!answers.appId || Validator.appId(answers.appId) !== true) {
       answers.appId = await prompt({
         type: 'input',
         name: 'value',
         message: 'appId (from https://console.cloud.tencent.com/developer)',
         validate: Validator.appId
-      }).then((res: {value: string}) => res.value);
-    
+      }).then((res: { value: string }) => res.value);
+    }
 
-    if (!answers.secretId || Validator.secretId(answers.secretId) !== true) 
+    if (!answers.secretId || Validator.secretId(answers.secretId) !== true) {
       answers.secretId = await prompt({
         type: 'input',
         name: 'value',
         message: 'secretId (from https://console.cloud.tencent.com/cam/capi)',
         validate: Validator.secretId
-      }).then((res: {value: string}) => res.value);
-    
+      }).then((res: { value: string }) => res.value);
+    }
 
-    if (!answers.secretKey || Validator.secretKey(answers.secretKey) !== true) 
+    if (!answers.secretKey || Validator.secretKey(answers.secretKey) !== true) {
       answers.secretKey = await prompt({
         type: 'input',
         name: 'value',
         message: 'secretKey (from https://console.cloud.tencent.com/cam/capi)',
         validate: Validator.secretKey
-      }).then((res: {value: string}) => res.value);
-    
+      }).then((res: { value: string }) => res.value);
+    }
   }
 
-  if (answers.example !== false) 
+  if (answers.example !== false) {
     answers.example = await prompt({
       type: 'confirm',
       name: 'value',
       message: 'Add example files',
       initial: true
-    }).then((res: {value: boolean}) => res.value);
-  
+    }).then((res: { value: boolean }) => res.value);
+  }
 
   mkdirSync(answers.name);
   writeFileSync(join(answers.name, 'faas.yaml'),
@@ -167,7 +167,7 @@ production:`);
     "tmp"
   ],
   "jest": {
-    "ts-jest",
+    "preset": "ts-jest",
     "collectCoverage": true,
     "collectCoverageFrom": [
       "**/*.ts"

--- a/packages/create-faas-app/src/action.ts
+++ b/packages/create-faas-app/src/action.ts
@@ -1,39 +1,39 @@
-import {Command} from 'commander';
-import {prompt} from 'enquirer';
-import {mkdirSync, writeFileSync, existsSync} from 'fs';
-import {join} from 'path';
-import {execSync} from 'child_process';
+import { Command } from 'commander';
+import { prompt } from 'enquirer';
+import { mkdirSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { execSync } from 'child_process';
 
 const Provider = ['tencentcloud', null];
 const Region = ['ap-beijing', 'ap-shanghai', 'ap-guangzhou', 'ap-hongkong'];
 
 const Validator = {
-  name(input: string) {
+  name (input: string) {
     const match = /^[a-z0-9-_]+$/i.test(input) ? true : 'Must be a-z, 0-9 or -_';
     if (match !== true) return match;
-    if (existsSync(input)) {
+    if (existsSync(input)) 
       return `${input} folder exists, please try another name`;
-    }
+    
     return true;
   },
-  provider(input: string | null) {
+  provider (input: string | null) {
     return Provider.includes(input) ? true : 'Unknow provider';
   },
-  region(input: string) {
+  region (input: string) {
     return Region.includes(input) ? true : 'Unknown region';
   },
-  appId(input: string) {
+  appId (input: string) {
     return /^[0-9]+$/.test(input) ? true : 'Wrong format';
   },
-  secretId(input: string) {
+  secretId (input: string) {
     return /^[a-zA-Z0-9]+$/.test(input) ? true : 'Wrong format';
   },
-  secretKey(input: string) {
+  secretKey (input: string) {
     return /^[a-zA-Z0-9]+$/.test(input) ? true : 'Wrong format';
   }
 };
 
-export async function action(options?: {
+export async function action (options?: {
   name?: string;
   region?: string;
   appId?: string;
@@ -51,14 +51,14 @@ export async function action(options?: {
     example?: boolean;
   } = Object.assign(options, {});
 
-  if (!options.name || Validator.name(options.name) !== true) {
+  if (!options.name || Validator.name(options.name) !== true) 
     answers.name = await prompt({
       type: 'input',
       name: 'value',
       message: 'Project name',
       validate: Validator.name
     }).then((res: {value: string}) => res.value);
-  }
+  
 
   answers.provider = await prompt({
     type: 'select',
@@ -77,7 +77,7 @@ export async function action(options?: {
   }).then((res: {value: string}) => res.value);
 
   if (answers.provider === 'tencentcloud') {
-    if (!answers.region || Validator.region(answers.region) !== true) {
+    if (!answers.region || Validator.region(answers.region) !== true) 
       answers.region = await prompt({
         type: 'select',
         name: 'value',
@@ -85,44 +85,44 @@ export async function action(options?: {
         choices: Region.concat([]), // choices 会修改 Region 对象，因此克隆一份
         validate: Validator.region
       }).then((res: {value: string}) => res.value);
-    }
+    
 
-    if (!answers.appId || Validator.appId(answers.appId) !== true) {
+    if (!answers.appId || Validator.appId(answers.appId) !== true) 
       answers.appId = await prompt({
         type: 'input',
         name: 'value',
         message: 'appId (from https://console.cloud.tencent.com/developer)',
         validate: Validator.appId
       }).then((res: {value: string}) => res.value);
-    }
+    
 
-    if (!answers.secretId || Validator.secretId(answers.secretId) !== true) {
+    if (!answers.secretId || Validator.secretId(answers.secretId) !== true) 
       answers.secretId = await prompt({
         type: 'input',
         name: 'value',
         message: 'secretId (from https://console.cloud.tencent.com/cam/capi)',
         validate: Validator.secretId
       }).then((res: {value: string}) => res.value);
-    }
+    
 
-    if (!answers.secretKey || Validator.secretKey(answers.secretKey) !== true) {
+    if (!answers.secretKey || Validator.secretKey(answers.secretKey) !== true) 
       answers.secretKey = await prompt({
         type: 'input',
         name: 'value',
         message: 'secretKey (from https://console.cloud.tencent.com/cam/capi)',
         validate: Validator.secretKey
       }).then((res: {value: string}) => res.value);
-    }
+    
   }
 
-  if (answers.example !== false) {
+  if (answers.example !== false) 
     answers.example = await prompt({
       type: 'confirm',
       name: 'value',
       message: 'Add example files',
       initial: true
     }).then((res: {value: boolean}) => res.value);
-  }
+  
 
   mkdirSync(answers.name);
   writeFileSync(join(answers.name, 'faas.yaml'),
@@ -201,7 +201,7 @@ tmp/
   "files.trimFinalNewlines": true
 }`);
 
-  execSync(`yarn --cwd ${answers.name} install`, {stdio: 'inherit'});
+  execSync(`yarn --cwd ${answers.name} install`, { stdio: 'inherit' });
 
   if (answers.example) {
     writeFileSync(join(answers.name, 'index.func.ts'),
@@ -229,7 +229,7 @@ describe('hello', function () {
   });
 });`);
 
-    execSync(`yarn --cwd ${answers.name} jest`, {stdio: 'inherit'});
+    execSync(`yarn --cwd ${answers.name} jest`, { stdio: 'inherit' });
   }
 }
 


### PR DESCRIPTION
### Problems

1. When serving the example function locally using `faas server` command, an error is returned from the requests to the endpoint:
```text
{"error":{"message":"Not found: /git/scf/.func.ts or /git/scf//index.func.ts"}}
```
2. When running `jest` command in the newly created app with the auto-generated example, errors are reported stating that some babel plugins are missing.

### Cause

1. The root cause is that the server looks for `index.func.ts` by default. But the example function resides in `hello.func.ts`.
2. `@babel/preset-env` and `@babel/preset-typescript` are missing

### Fix

1. change the filename of the function to `index.func.ts`
2. add the missing dependencies to the example `package.json` as dev dependencies

### Off-Topic

When running `node_modules/.bin/eslint --ext .ts packages/create-faas-app/src/ --fix` to lint the source codes, the `{` brackets after `if` statement are removed. I am not sure if it is the intended behaviour so please can a maintainer double check the eslint rules?