### PR TITLE
added eslint rule padded-blocks: ["error", "never"]

### DIFF
--- a/packages/eslint-config-recommended/index.js
+++ b/packages/eslint-config-recommended/index.js
@@ -56,6 +56,10 @@ module.exports = {
     'keyword-spacing': 'warn',
     'key-spacing': 'warn',
     'space-infix-ops': 'warn',
+    'padded-blocks': [
+      'error',
+      'never'
+    ],
     '@typescript-eslint/indent': [
       'error',
       2


### PR DESCRIPTION
添加eslint rule，对以下代码报错：

```typescript
if (a) {

    b();

}

if (a)
{

    b();

}

if (a) {

    b();
}

if (a) {
    b();

}
```

仅允许

```typescript
if (a) {
    b();
}

if (a)
{
    b();
}
```

详细参见[官方文档](https://eslint.org/docs/rules/padded-blocks)