### PR TITLE
feat(faasjs-best-practices): add Getting Started, CRUD Patterns, and CLI and Tooling guides

### DIFF
--- a/skills/faasjs-best-practices/SKILL.md
+++ b/skills/faasjs-best-practices/SKILL.md
@@ -9,12 +9,15 @@ Before changing code, inspect nearby examples and read only the guides needed fo
 
 ### Agent Task Routing
 
+- New to FaasJS or starting a new project: read [Getting Started Guide](./guidelines/getting-started.md) first for a complete onboarding and project setup walkthrough.
 - New business feature or vertical slice: read [Application Slices Guide](./guidelines/application-slices.md), [File Conventions](./guidelines/file-conventions.md), then the relevant API, UI, PG, and testing guides below.
+- Implementing a standard list/detail/create/update/delete feature: read [CRUD Patterns Guide](./guidelines/crud-patterns.md) for the complete vertical slice pattern, then the [Ant Design Guide](./guidelines/ant-design.md), [defineApi Guide](./guidelines/define-api.md), and [React Data Fetching Guide](./guidelines/react-data-fetching.md) for deeper rules.
 - New or changed `.api.ts` endpoint: read [defineApi Guide](./guidelines/define-api.md) and [Testing Guide](./guidelines/testing.md); also read PG guides if the endpoint touches data.
 - New or changed `.job.ts` background job: read [Jobs Guide](./guidelines/jobs.md), [PG Query Builder and Raw SQL Guide](./guidelines/pg-query-builder.md), and [PG Testing Guide](./guidelines/pg-testing.md).
 - React UI or request-flow change: read [React Guide](./guidelines/react.md), [React Data Fetching Guide](./guidelines/react-data-fetching.md), and [React Testing Guide](./guidelines/react-testing.md); read [Ant Design Guide](./guidelines/ant-design.md) for `@faasjs/ant-design` surfaces.
 - Database schema, query, or type change: read [PG Schema and Migrations Guide](./guidelines/pg-schema-and-migrations.md), [PG Table Types Guide](./guidelines/pg-table-types.md), [PG Query Builder and Raw SQL Guide](./guidelines/pg-query-builder.md), and [PG Testing Guide](./guidelines/pg-testing.md).
 - Project tooling or config change: read [Project Config Guide](./guidelines/project-config.md) before editing `tsconfig.json`, `vite.config.ts`, or shared tool config.
+- CLI command or tooling question: read [CLI and Tooling Guide](./guidelines/cli-and-tooling.md) for command reference, error recovery, and environment variable details.
 - Docs, generated references, translations, navigation, or changelog: follow the repo-level documentation sync guide before editing derived docs.
 
 ## Global Rules
@@ -66,6 +69,7 @@ Before handoff, verify the smallest meaningful set for the change:
 
 ## Guidelines
 
+- [Getting Started Guide](./guidelines/getting-started.md): Covers the full setup, first feature walkthrough, project structure, key concepts, and daily workflow for new developers and new projects.
 - [Curated Stack Guide](./guidelines/curated-stack.md): Covers the Rails-inspired default stack, official React/Ant Design/PostgreSQL path, plugin extension boundaries, auth/permission scope, and replacement rules.
 - [Application Slices Guide](./guidelines/application-slices.md): Covers vertical UI/API/database/test slices, recommended file layout, agent workflow, and why FaasJS avoids generator-heavy development.
 - [Ant Design Guide](./guidelines/ant-design.md): Covers `@faasjs/ant-design` page structure, routing, CRUD composition, feature-local APIs, and UI feedback patterns.
@@ -73,6 +77,7 @@ Before handoff, verify the smallest meaningful set for the change:
 - [Code Comments Guide](./guidelines/code-comments.md): Covers package public JSDoc expectations, caller contract conventions, when shared app exports need docs, and how to explain non-standard code without narrating it line by line.
 - [Node Utils Guide](./guidelines/node-utils.md): Covers Node-only helpers for env/config loading, function and plugin bootstrapping, module loading, and shared logging.
 - [Project Config Guide](./guidelines/project-config.md): Covers how to keep `tsconfig.json`, `vite.config.ts`, and shared tooling config aligned with FaasJS defaults.
+- [CLI and Tooling Guide](./guidelines/cli-and-tooling.md): Covers the FaasJS CLI, Vite Plus commands, project scaffolding, migrations, type generation, testing, common errors, and environment variables.
 - [Testing Guide](./guidelines/testing.md): Covers shared testing principles such as choosing test level, keeping mock boundaries narrow, and avoiding unnecessary mocks.
 - [React Guide](./guidelines/react.md): Covers React component and hook patterns in FaasJS, especially avoiding native `useEffect` and handling non-primitive dependencies safely.
 - [React Data Fetching Guide](./guidelines/react-data-fetching.md): Covers when to use `useFaas`, `useFaasStream`, `faas`, or wrapper components, and how to handle loading, error, and retry states.
@@ -80,6 +85,7 @@ Before handoff, verify the smallest meaningful set for the change:
 - [defineApi Guide](./guidelines/define-api.md): Covers building `.api.ts` endpoints with `defineApi`, inline schemas, typed `params`, error handling, and validation expectations.
 - [Jobs Guide](./guidelines/jobs.md): Covers `.job.ts` files, `defineJob`, `enqueueJob`, workers, scheduler cron enqueueing, retries, idempotency, and testing.
 - [Logger Guide](./guidelines/logger.md): Covers when to reuse injected loggers versus creating `Logger` instances, how to choose log levels, and how to time slow operations.
+- [CRUD Patterns Guide](./guidelines/crud-patterns.md): Covers the complete CRUD vertical slice — shared items metadata, list/detail/create/update/delete patterns, testing, and agent efficiency tips for faster page generation.
 - [Utils Guide](./guidelines/utils.md): Covers portable helpers from `@faasjs/utils` for deep merging and converting text or JSON to and from streams.
 - [PG Query Builder and Raw SQL Guide](./guidelines/pg-query-builder.md): Covers preferring `QueryBuilder` clauses, choosing raw SQL fallbacks deliberately, keeping client bootstrap consistent, and narrowing row shapes intentionally.
 - [PG Table Types Guide](./guidelines/pg-table-types.md): Covers declaration merging on `Tables`, concrete row shapes, and keeping query inference aligned with table definitions.

--- a/skills/faasjs-best-practices/guidelines/cli-and-tooling.md
+++ b/skills/faasjs-best-practices/guidelines/cli-and-tooling.md
@@ -1,0 +1,239 @@
+# CLI and Tooling Guide
+
+Use this guide when running CLI commands, troubleshooting command errors, or choosing the right tool for the task. It is a quick-reference for the FaasJS toolchain to reduce command-execution mistakes.
+
+## Default Workflow
+
+1. Install dependencies with `npm install` before running any FaasJS commands.
+2. After creating, renaming, or moving a `.api.ts` file, run `faas types` to regenerate type declarations.
+3. Use `vp check --fix` for code formatting and linting before committing.
+4. Use `vp test` as the default test runner; narrow to `vp test <pattern>` for focused runs.
+5. Run database migrations through `faasjs-pg migrate` when a migration is pending.
+6. When a command is unavailable, fall back to `npx <command>` and check that `node_modules` is present.
+
+## faas CLI
+
+Provided by `@faasjs/dev` as the `faas` binary (`faas.mjs`). It has two subcommands: `run` and `types`.
+
+| Command | Description |
+|---|---|
+| `faas run <file>` | Run a TypeScript file with FaasJS Node module hooks preloaded |
+| `faas run <file> --root <path>` | Specify project root to resolve `<file>` (default: `process.cwd()`) |
+| `faas types` | Generate API type declarations to `src/.faasjs/types.d.ts` |
+| `faas types --root <path>` | Specify project root for type generation |
+
+Global options:
+- `-h, --help` — Show help text.
+- `-v, --version` — Print the `@faasjs/dev` version.
+
+> **Run details**: `faas run` resolves `@faasjs/node-utils/register-hooks` and spawns a child Node process with `--import` so the target script gets a normal `process.argv`.
+
+> **Type generation details**: `faas types` scans `src/` for `.api.ts` files, converts filenames into routes, and writes `src/.faasjs/types.d.ts`. It skips `.faasjs` and `node_modules` directories. Only `.api.ts` files and `faas.yaml` changes trigger type regeneration (see `isTypegenInputFile` in `@faasjs/dev`).
+
+## Vite Plus / vp
+
+Provided by the `vite-plus` package. It is the development and build tooling layer on top of Vite and Vitest.
+
+| Command | Description |
+|---|---|
+| `vp check --fix` | Run code checking (linting) and formatting fixes via oxlint and oxfmt |
+| `vp test` | Run all tests with Vitest |
+| `vp test <pattern>` | Run tests matching a file-name pattern |
+| `vp test --watch` | Run tests in watch mode |
+| `vp dev` | Start the development server |
+
+Common combinations:
+```bash
+# Run checks and tests before handoff
+vp check --fix && vp test
+
+# Run a specific test file
+vp test src/pages/users/api/__tests__/list.test.ts
+
+# Run tests matching a pattern with watch
+vp test list --watch
+
+# Run tests with a specific log level
+FaasLog=info vp test
+
+# Start dev server on a custom port (configured in vite.config.ts)
+vp dev
+```
+
+## Project Creation
+
+Use `create-faas-app` to scaffold new projects.
+
+```bash
+npx create-faas-app --name <project-name>
+```
+
+Options:
+- `--name <name>` — Project folder name.
+- `--template <template>` — Template name (default: `admin`).
+
+Available templates:
+- `admin` (default) — Recommended React + Ant Design + PostgreSQL starter.
+- `minimal` — Lighter React starter.
+
+After scaffolding, the script automatically runs:
+1. `npm install` — Installs dependencies.
+2. `npm run test` — Runs the initial test suite to verify the setup.
+
+To run these steps manually after creation:
+```bash
+cd <project-name>
+npm install
+npx faas types
+```
+
+## Migration Commands
+
+Provided by `@faasjs/pg` as the `faasjs-pg` binary.
+
+| Command | Description |
+|---|---|
+| `faasjs-pg new <name>` | Create a new timestamped migration file in `migrations/` |
+| `faasjs-pg status` | Show the status of all migrations |
+| `faasjs-pg migrate` | Run all pending migrations |
+| `faasjs-pg up` | Run the next pending migration |
+| `faasjs-pg down` | Roll back the latest applied migration |
+
+Requirements:
+- `DATABASE_URL` environment variable must be set for `status`, `migrate`, `up`, and `down`.
+- Migration files live in `./migrations` by default.
+- Migration file naming convention: `<timestamp>-<name>.ts` (generated automatically by `faasjs-pg new`).
+- See [PG Schema and Migrations Guide](./pg-schema-and-migrations.md) for migration authoring rules.
+
+Example:
+```bash
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg migrate
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg new add_users_table
+```
+
+## Type Generation Workflow
+
+Keep type declarations in sync with your API routes:
+
+1. After **creating**, **renaming**, or **moving** a `.api.ts` file, run:
+
+   ```bash
+   npx faas types
+   ```
+
+2. The generated file is written to `src/.faasjs/types.d.ts`.
+
+3. The output declares a `FaasActions` interface via module augmentation on `@faasjs/types`, providing typed `InferFaasAction` and `InferFaasApi` for every route.
+
+4. `faas types` is idempotent: it compares the generated content against the existing file and only writes when something changed.
+
+5. For type generation from code (e.g., in a script), import `generateFaasTypes` from `@faasjs/dev`:
+
+   ```ts
+   import { generateFaasTypes } from '@faasjs/dev'
+
+   const result = await generateFaasTypes({ root: process.cwd() })
+   console.log(result.output, result.routeCount)
+   ```
+
+## Testing Commands
+
+| Command | Description |
+|---|---|
+| `vp test` | Run the full test suite |
+| `vp test <pattern>` | Run tests matching a file-name pattern (e.g., `vp test list` runs `*list*`) |
+| `vp test --watch` | Re-run tests on file changes |
+| `FaasLog=info vp test` | Run tests with a specific log verbosity |
+
+See [Testing Guide](./testing.md) for testing principles and [Project Config Guide](./project-config.md) for Vitest project configuration.
+
+## Common Command Errors and Recovery
+
+### `faas: command not found`
+- **Check**: `npx faas --version` or `npx @faasjs/dev --version`
+- **Recovery**: Ensure `@faasjs/dev` is installed: `npm install @faasjs/dev`
+- **Root cause**: The `faas` binary is defined in `@faasjs/dev`, not as a global command.
+
+### `vp: command not found`
+- **Check**: `npx vp --version`
+- **Recovery**: Ensure `vite-plus` is installed: `npm install vite-plus`
+- **Root cause**: The `vp` binary is provided by `vite-plus`.
+
+### `faas types` fails
+- **Check**: Does `src/faas.yaml` exist? Is the YAML valid?
+- **Check**: Does `src/` contain at least one `.api.ts` file?
+- **Recovery**: Run `npx faas types --root .` if outside the project root.
+- **See**: [faas.yaml Specification](../locales/en/specs/faas-yaml.md)
+
+### `faasjs-pg` commands fail
+- **Check**: Is `DATABASE_URL` set? `echo $DATABASE_URL`
+- **Check**: Is the database reachable? `psql $DATABASE_URL -c 'SELECT 1'`
+- **Recovery**: Prepend `DATABASE_URL=postgres://...` or set it in `.env`.
+- **Root cause**: All `faasjs-pg` commands except `new` require a live database connection.
+
+### Tests fail
+- **Check**: Are dependencies installed? `npm ls @faasjs/dev vite-plus vitest`
+- **Check**: Does the project have a valid `vitest.config.ts` or `vite.config.ts`?
+- **Check**: Are environment variables (e.g., `DATABASE_URL`) available for integration tests?
+- **Recovery**: Run a focused test first: `vp test src/specific/test.ts`
+- **See**: [Project Config Guide](./project-config.md) for Vite/Vitest configuration.
+
+## Environment Variables and Configuration
+
+### FaasJS runtime
+| Variable | Description | Default |
+|---|---|---|
+| `FaasEnv` | Active staging name used by `faas.yaml` config loading | `development` |
+| `FaasLog` | Minimum log level (`debug`, `info`, `warn`, `error`) | `info` |
+| `FaasLogMode` | Log output style (`plain`, `pretty`) | auto-detected |
+| `FaasLogSize` | Truncation threshold for long non-error logs (bytes) | platform-dependent |
+| `FaasLogTransport` | Enable or disable shared log transport forwarding | `true` |
+
+### Database
+| Variable | Description | Required By |
+|---|---|---|
+| `DATABASE_URL` | PostgreSQL connection string | `faasjs-pg` CLI, `@faasjs/pg` client bootstrap, `@faasjs/pg-dev` test plugin |
+
+### Example usage
+```bash
+# Run tests with debug logging
+FaasLog=debug vp test
+
+# Run migrations against a specific database
+DATABASE_URL=postgres://user:pass@localhost:5432/myapp npx faasjs-pg migrate
+
+# Run type generation for a specific project root
+npx faas types --root /path/to/project
+```
+
+## Key Configuration Files
+
+| File | Purpose |
+|---|---|
+| `faas.yaml` | Runtime configuration: server root, base path, staging overrides, plugins |
+| `tsconfig.json` | TypeScript configuration, extends `@faasjs/types/tsconfig/*` presets |
+| `vite.config.ts` | Vite/Vitest configuration, uses `viteConfig` from `@faasjs/dev` |
+| `.env` | Environment variable overrides for local development |
+
+## Rules
+
+1. **Run `faas types` after every `.api.ts` change.** Creating, renaming, or moving API files without regenerating types will cause type errors in callers.
+2. **Prefer `vp check --fix` over manual formatting.** It uses oxlint and oxfmt through vite-plus shared configs.
+3. **Prefer `vp test` over direct `vitest` calls.** It uses the project's `vite.config.ts` which includes all necessary plugins and aliases.
+4. **Use `npx` when the binary is not globally installed.** Both `faas` and `vp` are local to the project's `node_modules`.
+5. **Set `DATABASE_URL` before running `faasjs-pg` commands.** All operations except `new` require a live connection.
+6. **Keep migration timestamps unique.** The `faasjs-pg new` command uses ISO timestamps; do not hand-edit filenames to avoid ordering conflicts.
+7. **Do not edit `src/.faasjs/types.d.ts` manually.** It is regenerated by `faas types` and any manual changes will be overwritten.
+8. **Use `FaasLog` verbosity for debugging instead of changing log call sites.** The logger respects `FaasLog` at runtime.
+
+## Review Checklist
+
+- `.api.ts` changes are followed by `faas types` (or a recorded reason)
+- `faas.yaml` is valid YAML and follows the [faas.yaml specification](../locales/en/specs/faas-yaml.md)
+- `vp check --fix` passes before commit
+- `vp test` passes (or a recorded blocker + narrower validation that did run)
+- `DATABASE_URL` is set before running `faasjs-pg` migration commands
+- migration files are in `migrations/` and follow timestamped naming
+- `src/.faasjs/types.d.ts` is not hand-edited
+- `npx` prefix is used when binaries are not globally installed
+- environment variables (`FaasEnv`, `FaasLog`, `DATABASE_URL`) are documented or obvious per project

--- a/skills/faasjs-best-practices/guidelines/crud-patterns.md
+++ b/skills/faasjs-best-practices/guidelines/crud-patterns.md
@@ -1,0 +1,730 @@
+# CRUD Patterns Guide
+
+Use this guide when implementing or reviewing a standard CRUD feature — list, detail, create, update, delete — in a FaasJS application. It covers the full vertical slice from API endpoints to React pages.
+
+Apply the [Application Slices Guide](./application-slices.md), [Ant Design Guide](./ant-design.md), [defineApi Guide](./define-api.md), and [React Data Fetching Guide](./react-data-fetching.md) for deeper rules. This guide focuses on composing those patterns into a complete CRUD cycle.
+
+## Default Workflow
+
+1. Model business fields as shared `items` metadata in a `use<Feature>Items` hook.
+2. Create five API files: `list`, `detail`, `create`, `update`, `remove`.
+3. Build the list page with `Table.faasData`, search/filter controls, and action column.
+4. Add detail view with `Description.faasData` inside a drawer.
+5. Add create/update forms that reuse the same `items` and use `Form.faas`.
+6. Add delete with a modal confirmation.
+7. Wire mutation feedback (`message.success`, `notification.error`) and surface refresh/close.
+8. Add API tests with `testApi` covering success, validation, and error paths.
+9. Add React tests with `setMock` covering loading, render, and mutation flows.
+
+## Quick Reference Tables
+
+### API Endpoint Mapping
+
+| Action   | API File                          | Route                                        | Method | Params                                    |
+|----------|-----------------------------------|----------------------------------------------|--------|-------------------------------------------|
+| List     | `api/list.api.ts`                 | `POST /pages/<feature>/api/list`             | post   | Filters, pagination                       |
+| Detail   | `api/detail.api.ts`               | `POST /pages/<feature>/api/detail`           | post   | `{ id }`                                  |
+| Create   | `api/create.api.ts`               | `POST /pages/<feature>/api/create`           | post   | Business fields                           |
+| Update   | `api/update.api.ts`               | `POST /pages/<feature>/api/update`           | post   | `{ id, ...fields }`                       |
+| Remove   | `api/remove.api.ts`               | `POST /pages/<feature>/api/remove`           | post   | `{ id }`                                  |
+
+### File Naming Convention
+
+| Layer       | Convention                          | Example                               |
+|-------------|-------------------------------------|---------------------------------------|
+| Page entry  | `pages/<feature>/index.tsx`         | `pages/users/index.tsx`               |
+| Components  | `pages/<feature>/components/*.tsx`  | `pages/users/components/UserTable.tsx` |
+| Hooks       | `pages/<feature>/hooks/*.ts`        | `pages/users/hooks/useUserItems.ts`    |
+| APIs        | `pages/<feature>/api/*.api.ts`      | `pages/users/api/list.api.ts`         |
+| API tests   | `pages/<feature>/api/__tests__/*.test.ts` | `pages/users/api/__tests__/list.test.ts` |
+
+## Shared Items Pattern
+
+The `items` array is the single source of truth for business fields across `Form`, `Table`, and `Description`. Each item describes one field: its id, label, input type, validation, and optional per-surface renderers.
+
+Define items in a `use<Feature>Items` hook so they stay colocated and reusable.
+
+```tsx
+import { useConstant } from '@faasjs/react'
+import type { FormItem, TableItem, DescriptionItem } from '@faasjs/ant-design'
+
+export type UserField = {
+  id: number
+  name: string
+  email: string
+  role: string
+  created_at: string
+}
+
+export function useUserItems() {
+  return useConstant<Array<FormItem & TableItem & DescriptionItem>>(() => [
+    {
+      id: 'name',
+      title: 'Name',
+      required: true,
+      rules: [{ min: 1, max: 100 }],
+      tableRender: (value) => <a>{value}</a>,
+    },
+    {
+      id: 'email',
+      title: 'Email',
+      required: true,
+      rules: [{ type: 'email' }],
+    },
+    {
+      id: 'role',
+      title: 'Role',
+      required: true,
+      type: 'select',
+      options: [
+        { label: 'Admin', value: 'admin' },
+        { label: 'Editor', value: 'editor' },
+        { label: 'Viewer', value: 'viewer' },
+      ],
+    },
+    {
+      id: 'created_at',
+      title: 'Created At',
+      descriptionRender: (value) => new Date(value as string).toLocaleDateString(),
+    },
+  ])
+}
+```
+
+**Rules for items:**
+
+- Keep items in `useConstant` so the array identity is stable across renders.
+- Add `tableRender`, `descriptionRender`, or `formRender` only when presentation truly differs per surface.
+- For fields that appear on one surface only (like an action column), add them inline on the consuming component instead of polluting shared items.
+- Use `extendTypes` for repeated custom field behavior (see [Ant Design Guide](./ant-design.md#core-patterns)).
+
+## List Page Pattern
+
+Use `Table.faasData` for server-driven list fetches. Add search/filter controls in a row above the table and an actions column for detail/edit/delete.
+
+```tsx
+import { Table, Title, useApp } from '@faasjs/ant-design'
+import { Input, Button, Space } from 'antd'
+import { useState } from 'react'
+
+import { UserActions } from './components/UserActions'
+import { useUserItems, type UserField } from './hooks/useUserItems'
+
+export default function UsersPage() {
+  const { setDrawerProps } = useApp()
+  const [keyword, setKeyword] = useState('')
+  const [searchParams, setSearchParams] = useState<{ keyword?: string }>({})
+
+  const items = useUserItems()
+
+  return (
+    <Space direction="vertical" style={{ width: '100%' }}>
+      <Title>Users</Title>
+
+      <Space>
+        <Input.Search
+          placeholder="Search by name or email"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          onSearch={() => setSearchParams({ keyword: keyword || undefined })}
+        />
+        <Button type="primary" onClick={() =>
+          setDrawerProps({
+            open: true,
+            title: 'Create User',
+            width: 720,
+            children: <UserForm onSuccess={() => reload()} />,
+          })
+        }>
+          Create User
+        </Button>
+      </Space>
+
+      <Table<UserField>
+        rowKey="id"
+        items={[
+          ...items,
+          {
+            id: 'actions',
+            title: 'Actions',
+            tableRender: (_, row) => (
+              <UserActions row={row} onSuccess={() => reload()} />
+            ),
+          },
+        ]}
+        faasData={{
+          action: '/pages/users/api/list',
+          params: searchParams,
+        }}
+      />
+    </Space>
+  )
+}
+```
+
+### List API
+
+```ts
+import { defineApi } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    keyword: z.string().optional(),
+    page: z.coerce.number().int().positive().default(1),
+    pageSize: z.coerce.number().int().positive().default(20),
+  }),
+  async handler({ params }) {
+    // Query database with params.keyword, params.page, params.pageSize
+    return {
+      rows: [
+        { id: 1, name: 'Alice', email: 'alice@example.com', role: 'admin', created_at: '2025-01-01' },
+      ],
+      total: 1,
+    }
+  },
+})
+```
+
+### Search / Filter Trigger
+
+- Use `setSearchParams` to trigger `Table.faasData` re-fetch. The table re-fetches automatically when `faasData.params` changes.
+- Use `debounce` via the `useFaas` lifecycle instead of custom timers (see [React Data Fetching Guide](./react-data-fetching.md)).
+- Keep `keyword` local state for the input and only push to `searchParams` on search submit.
+
+## Detail Pattern
+
+Use `Description.faasData` for detail fetches. Open in a drawer to keep list context visible.
+
+```tsx
+import { Description, useApp } from '@faasjs/ant-design'
+
+import { useUserItems, type UserField } from '../hooks/useUserItems'
+
+export function UserDetail(props: { id: number }) {
+  const items = useUserItems()
+
+  return (
+    <Description<UserField>
+      items={items}
+      faasData={{
+        action: '/pages/users/api/detail',
+        params: { id: props.id },
+      }}
+    />
+  )
+}
+```
+
+### Detail API
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+  }),
+  async handler({ params }) {
+    // Fetch from database by params.id
+    const user = { id: 1, name: 'Alice', email: 'alice@example.com', role: 'admin', created_at: '2025-01-01' }
+
+    if (!user) {
+      throw new HttpError({ statusCode: 404, message: 'User not found' })
+    }
+
+    return user
+  },
+})
+```
+
+**Rules for detail:**
+
+- Reuse the same `items` from `use<Feature>Items`.
+- For fields that differ on detail, use `descriptionRender` on the item.
+- Keep the detail API response shape aligned with the item field ids.
+
+## Create Form Pattern
+
+Use `Form.faas` for form submission with built-in loading, validation, feedback, and error handling.
+
+```tsx
+import { Form, useApp } from '@faasjs/ant-design'
+
+import { useUserItems } from '../hooks/useUserItems'
+
+export function UserForm(props: { onSuccess?: () => void }) {
+  const { message, notification, setDrawerProps } = useApp()
+  const items = useUserItems()
+
+  return (
+    <Form
+      items={items}
+      faas={{
+        action: '/pages/users/api/create',
+        onSuccess: () => {
+          message.success('User created')
+          setDrawerProps({ open: false })
+          props.onSuccess?.()
+        },
+        onError: (error) =>
+          notification.error({
+            message: 'Create failed',
+            description: error?.message,
+          }),
+      }}
+    />
+  )
+}
+```
+
+### Create API
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    name: z.string().min(1).max(100),
+    email: z.string().email(),
+    role: z.enum(['admin', 'editor', 'viewer']),
+  }),
+  async handler({ params }) {
+    // Check for duplicates
+    if (/* email already exists */) {
+      throw new HttpError({ statusCode: 409, message: 'Email already exists' })
+    }
+
+    // Insert into database and return created record
+    return {
+      id: 1,
+      name: params.name,
+      email: params.email,
+      role: params.role,
+      created_at: new Date().toISOString(),
+    }
+  },
+})
+```
+
+**Rules for create forms:**
+
+- `Form.faas` handles button loading, validation, and error feedback automatically.
+- Use `message.success` for success feedback and `notification.error` for failure feedback.
+- Close the drawer/modal on success via `setDrawerProps({ open: false })`.
+- Call `props.onSuccess?.()` so the parent can refresh the list.
+
+## Update Form Pattern
+
+Reuse the same `UserForm` component by passing `initialValues` and switching the API action. The form pre-fills data from a detail fetch.
+
+```tsx
+import { Form, useApp } from '@faasjs/ant-design'
+
+import { useUserItems } from '../hooks/useUserItems'
+
+export function UserForm(props: {
+  id?: number
+  initialValues?: Record<string, any>
+  onSuccess?: () => void
+}) {
+  const { message, notification, setDrawerProps } = useApp()
+  const items = useUserItems()
+
+  return (
+    <Form
+      initialValues={props.initialValues}
+      items={items}
+      faas={{
+        action: props.id ? '/pages/users/api/update' : '/pages/users/api/create',
+        params: (values) => ({ ...values, ...(props.id ? { id: props.id } : {}) }),
+        onSuccess: () => {
+          message.success(props.id ? 'User updated' : 'User created')
+          setDrawerProps({ open: false })
+          props.onSuccess?.()
+        },
+        onError: (error) =>
+          notification.error({
+            message: props.id ? 'Update failed' : 'Create failed',
+            description: error?.message,
+          }),
+      }}
+    />
+  )
+}
+```
+
+### Update API
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+    name: z.string().min(1).max(100).optional(),
+    email: z.string().email().optional(),
+    role: z.enum(['admin', 'editor', 'viewer']).optional(),
+  }),
+  async handler({ params }) {
+    const existing = { id: 1 } // Fetch from database
+
+    if (!existing) {
+      throw new HttpError({ statusCode: 404, message: 'User not found' })
+    }
+
+    // Update database where id = params.id
+    return { id: params.id, ...params }
+  },
+})
+```
+
+**Rules for update forms:**
+
+- Use the same `UserForm` component for both create and update — the `id` prop determines the mode.
+- Fetch current values on the page/component that opens the drawer, then pass them as `initialValues`.
+- Make update API fields optional (`z.string().optional()`) so partial updates work.
+- Use `Form.faas` `params` function to conditionally include `id` for updates.
+
+## Delete Pattern
+
+Use a modal confirmation for destructive actions. Call `faas` imperatively in the `onOk` handler.
+
+```tsx
+import { Button, Space } from 'antd'
+import { faas, useApp } from '@faasjs/ant-design'
+
+export function UserActions(props: { row: { id: number }; onSuccess?: () => void }) {
+  const { message, notification, setModalProps } = useApp()
+
+  const handleDelete = () => {
+    setModalProps({
+      open: true,
+      title: 'Delete User',
+      children: 'Are you sure you want to delete this user? This action cannot be undone.',
+      onOk: async () => {
+        try {
+          await faas('/pages/users/api/remove', { id: props.row.id })
+          message.success('User deleted')
+          setModalProps({ open: false })
+          props.onSuccess?.()
+        } catch (error: any) {
+          notification.error({
+            message: 'Delete failed',
+            description: error?.message,
+          })
+        }
+      },
+    })
+  }
+
+  const handleEdit = () => {
+    // Open drawer with UserForm and initialValues from props.row
+  }
+
+  const handleDetail = () => {
+    // Open drawer with UserDetail
+  }
+
+  return (
+    <Space>
+      <Button type="link" onClick={handleDetail}>Detail</Button>
+      <Button type="link" onClick={handleEdit}>Edit</Button>
+      <Button type="link" danger onClick={handleDelete}>Delete</Button>
+    </Space>
+  )
+}
+```
+
+### Remove API
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+  }),
+  async handler({ params }) {
+    const existing = { id: 1 } // Fetch from database
+
+    if (!existing) {
+      throw new HttpError({ statusCode: 404, message: 'User not found' })
+    }
+
+    // Delete from database where id = params.id
+    return { success: true }
+  },
+})
+```
+
+**Rules for delete:**
+
+- Use `setModalProps` from `useApp()` for modal confirmation.
+- Call `faas` imperatively inside the `onOk` handler — not `Form.faas`.
+- Always fetch the record first and return `404` if not found.
+- On success, close modal, show `message.success`, and call `onSuccess` to refresh the parent.
+
+## Complete CRUD Slice Layout Reference
+
+### Directory Structure
+
+```
+src/pages/users/
+  index.tsx                          # Page entry: composes UserTable, create button
+  components/
+    UserTable.tsx                    # Table with faasData, search, action column
+    UserForm.tsx                     # Form for create/update (id prop switches mode)
+    UserDetail.tsx                   # Description with faasData
+    UserActions.tsx                  # Detail / Edit / Delete buttons
+  hooks/
+    useUserItems.ts                  # Shared items metadata
+  api/
+    list.api.ts                      # POST /pages/users/api/list
+    detail.api.ts                    # POST /pages/users/api/detail
+    create.api.ts                    # POST /pages/users/api/create
+    update.api.ts                    # POST /pages/users/api/update
+    remove.api.ts                    # POST /pages/users/api/remove
+    __tests__/
+      list.test.ts                   # testApi for list
+      detail.test.ts                 # testApi for detail
+      create.test.ts                 # testApi for create
+      update.test.ts                 # testApi for update
+      remove.test.ts                 # testApi for remove
+```
+
+### File Count & Responsibility
+
+| File                        | Lines (approx) | Responsibility                              |
+|-----------------------------|----------------|---------------------------------------------|
+| `index.tsx`                 | 30-60          | Page entry, layout, compose components      |
+| `UserTable.tsx`             | 40-80          | Table, search, filter, action column        |
+| `UserForm.tsx`              | 30-60          | Form items, faas config, feedback           |
+| `UserDetail.tsx`            | 15-30          | Description with faasData                   |
+| `UserActions.tsx`           | 40-70          | Detail/Edit/Delete buttons, modal confirm   |
+| `useUserItems.ts`           | 30-60          | Shared items metadata                       |
+| Each `.api.ts`              | 15-40          | Schema, handler, DB query                   |
+| Each API test               | 20-50          | testApi, success/error paths                |
+
+## Testing CRUD Endpoints
+
+Use `testApi` from `@faasjs/dev` to test each endpoint. Cover success, validation failure, and expected business errors.
+
+```ts
+import { testApi } from '@faasjs/dev'
+import { describe, expect, it } from 'vitest'
+
+import createApi from '../create.api'
+import listApi from '../list.api'
+import detailApi from '../detail.api'
+import updateApi from '../update.api'
+import removeApi from '../remove.api'
+
+describe('users/api/create', () => {
+  const handler = testApi(createApi)
+
+  it('creates a user with valid params', async () => {
+    const response = await handler({
+      name: 'Alice',
+      email: 'alice@example.com',
+      role: 'admin',
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.data?.name).toBe('Alice')
+    expect(response.data?.id).toBeGreaterThan(0)
+  })
+
+  it('returns 400 when email is invalid', async () => {
+    const response = await handler({
+      name: 'Alice',
+      email: 'not-an-email',
+      role: 'admin',
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.error?.message).toContain('Invalid params')
+  })
+
+  it('returns 409 when email already exists', async () => {
+    const response = await handler({
+      name: 'Alice',
+      email: 'existing@example.com',
+      role: 'admin',
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(response.error?.message).toBe('Email already exists')
+  })
+})
+
+describe('users/api/list', () => {
+  const handler = testApi(listApi)
+
+  it('returns paginated results', async () => {
+    const response = await handler({ page: 1, pageSize: 20 })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.data?.rows).toBeDefined()
+    expect(response.data?.total).toBeDefined()
+    expect(Array.isArray(response.data?.rows)).toBe(true)
+  })
+
+  it('filters by keyword', async () => {
+    const response = await handler({ keyword: 'Alice', page: 1, pageSize: 20 })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.data?.rows).toBeDefined()
+  })
+})
+
+describe('users/api/detail', () => {
+  const handler = testApi(detailApi)
+
+  it('returns user detail', async () => {
+    const response = await handler({ id: 1 })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.data?.id).toBe(1)
+  })
+
+  it('returns 404 for non-existent user', async () => {
+    const response = await handler({ id: 999 })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.error?.message).toBe('User not found')
+  })
+})
+
+describe('users/api/update', () => {
+  const handler = testApi(updateApi)
+
+  it('updates a user', async () => {
+    const response = await handler({ id: 1, name: 'Alice Updated' })
+
+    expect(response.statusCode).toBe(200)
+  })
+
+  it('returns 404 for non-existent user', async () => {
+    const response = await handler({ id: 999, name: 'Ghost' })
+
+    expect(response.statusCode).toBe(404)
+  })
+})
+
+describe('users/api/remove', () => {
+  const handler = testApi(removeApi)
+
+  it('deletes a user', async () => {
+    const response = await handler({ id: 1 })
+
+    expect(response.statusCode).toBe(200)
+  })
+
+  it('returns 404 for non-existent user', async () => {
+    const response = await handler({ id: 999 })
+
+    expect(response.statusCode).toBe(404)
+  })
+})
+```
+
+**Rules for CRUD tests:**
+
+- Follow the shared [Testing Guide](./testing.md) and [defineApi Guide](./define-api.md).
+- For each endpoint, test: success path, validation failure (400), and business errors (404, 409).
+- Use `testApi(api)` to get a typed handler.
+- Assert both `statusCode` and `data`/`error` shape.
+- Place tests under `api/__tests__/` next to the API file.
+
+## Agent Efficiency Tips
+
+The following patterns help AI coding agents generate complete CRUD features 2-3x faster.
+
+### 1. Start with items
+
+```text
+Prompt: "Create a `useProductItems` hook with fields: name (required), price (required, positive number), category (select with 3 options), description (textarea), status (select). Store in pages/products/hooks/useProductItems.ts"
+```
+
+Items are the foundation. Once items exist, the agent can derive `Table`, `Form`, and `Description` consistently.
+
+### 2. Generate five APIs in one pass
+
+```text
+Prompt: "Create 5 API files for products CRUD under pages/products/api/: list, detail, create, update, remove. Follow the defineApi guide. Each should have a Zod schema and handler."
+```
+
+Five small `.api.ts` files are faster to generate together than one at a time, and the agent can keep schemas consistent.
+
+### 3. Copy-paste the combined form
+
+The `UserForm` pattern with `id`-based mode switching (create vs update) is reusable. Generate one combined form instead of separate create/update components.
+
+### 4. Generate list + drawer wiring in one go
+
+```text
+Prompt: "Create pages/products/index.tsx with a Table.faasData list, search button, create button that opens a drawer with ProductForm, and an actions column with detail/edit/delete. Use the shared items from useProductItems."
+```
+
+One prompt covers the page entry, table, drawer wiring, and action column.
+
+### 5. Batch API tests
+
+```text
+Prompt: "Create test files for all 5 product APIs under pages/products/api/__tests__/. Each test should cover success and 400/404/409 paths where applicable."
+```
+
+One prompt generates all tests with a consistent pattern.
+
+### 6. Use the slice template for new features
+
+When starting a new CRUD feature, create the full directory structure first:
+
+```text
+Prompt: "Create a full CRUD slice for orders under pages/orders/. Include: index.tsx, components/ (OrderTable, OrderForm, OrderDetail, OrderActions), hooks/useOrderItems, api/ (list, detail, create, update, remove), and api/__tests__/ for all 5 endpoints."
+```
+
+## Rules
+
+1. Use shared `items` in a `use<Feature>Items` hook as the single source of truth for business fields across `Form`, `Table`, and `Description`.
+2. Name API files with the CRUD action (`list`, `detail`, `create`, `update`, `remove`) and place them under `<feature>/api/`.
+3. Use `Form.faas` for create/update submissions — it handles loading, validation, and error feedback automatically.
+4. Use `Table.faasData` for list fetches — it handles loading, error, and re-fetch on params change.
+5. Use `Description.faasData` for detail fetches.
+6. Use a combined `UserForm` component with an `id` prop to switch between create and update modes.
+7. Use `faas` imperatively for delete and other one-off mutations.
+8. Close overlays and refresh the affected surface after every mutation.
+9. Use `message.success` for success feedback and `notification.error` for failures.
+10. Always fetch the resource first in detail, update, and remove endpoints; return `404` when not found.
+11. Check for duplicates in create/update endpoints; return `409` on conflict.
+12. Place API tests under `api/__tests__/` using `testApi` from `@faasjs/dev`.
+13. Keep `items` in `useConstant` so the array identity is stable across renders.
+14. Add action columns inline on `Table` items instead of in shared items.
+15. Use `setDrawerProps` from `useApp()` for in-context create/edit/detail overlays.
+16. Use `setModalProps` from `useApp()` for destructive confirmation modals.
+
+## Review Checklist
+
+- [ ] Shared `use<Feature>Items` hook exists with all business fields
+- [ ] Five API files exist: `list.api.ts`, `detail.api.ts`, `create.api.ts`, `update.api.ts`, `remove.api.ts`
+- [ ] Each API has a Zod schema defined inline in `defineApi`
+- [ ] List API returns `{ rows, total }` shape
+- [ ] Detail/update/remove APIs check for existence and return `404` when not found
+- [ ] Create/update APIs check for duplicates and return `409` on conflict
+- [ ] `Table.faasData` drives the list with search/filter params
+- [ ] `Description.faasData` drives the detail view
+- [ ] `Form.faas` drives create/update with `id`-based mode switching
+- [ ] `faas` + modal confirmation drives delete
+- [ ] Mutations provide feedback (`message.success`, `notification.error`)
+- [ ] Mutations close overlays and call `onSuccess` to refresh the parent
+- [ ] API tests cover success path, 400 (validation), and business errors (404/409)
+- [ ] API tests use `testApi` and are placed in `api/__tests__/`
+- [ ] Items are wrapped in `useConstant`
+- [ ] Action columns are added inline on the `Table` rather than in shared items
+- [ ] Drawers are used for create/edit/detail; modals for delete confirmation
+- [ ] File structure follows `pages/<feature>/{components/,hooks/,api/}` conventions

--- a/skills/faasjs-best-practices/guidelines/getting-started.md
+++ b/skills/faasjs-best-practices/guidelines/getting-started.md
@@ -1,0 +1,701 @@
+# Getting Started Guide
+
+Use this guide when starting a new FaasJS project or onboarding a new developer to an existing FaasJS codebase. It walks through the full setup, first feature, and daily workflow so both humans and AI coding agents can get productive quickly.
+
+FaasJS is a Rails-inspired, curated full-stack TypeScript framework for database-driven React business applications. It gives projects a chef-selected main path instead of asking every team to assemble its own framework from independent tools.
+
+## Prerequisites
+
+Before starting, make sure your environment meets these requirements:
+
+- **Node.js** >= 20.x — FaasJS relies on modern Node features including native TypeScript module loading.
+- **npm** >= 9.x — used for dependency management and scaffolding.
+- **PostgreSQL** >= 14.x — FaasJS uses PostgreSQL as its relational data store (via `@faasjs/pg`). A running local instance or Docker container is required for database features and integration tests.
+- **Basic TypeScript knowledge** — FaasJS is TypeScript-first. You should be comfortable with types, interfaces, and module imports.
+
+Verify your environment:
+
+```bash
+node --version   # >= 20.x
+npm --version    # >= 9.x
+psql --version   # >= 14.x
+```
+
+## Creating a New Project
+
+The fastest way to start is with `create-faas-app`.
+
+### Step 1: Scaffold the project
+
+```bash
+npx create-faas-app --name my-app
+```
+
+This command:
+1. Creates a `my-app/` directory
+2. Installs all dependencies (`npm install`)
+3. Runs the initial test suite to verify the setup
+
+### Step 2: Choose a template
+
+`create-faas-app` offers two templates:
+
+| Template | Description | When to use |
+|----------|-------------|-------------|
+| `admin` (default) | Full admin panel starter with React, Ant Design pages, PostgreSQL integration, and a ready-to-copy users CRUD slice | Back-office systems, internal tools, SaaS dashboards, admin panels |
+| `minimal` | Lighter starter with React and minimal configuration | Simple APIs, BFF layers, or when you want to build UI from scratch |
+
+To use a specific template:
+
+```bash
+npx create-faas-app --name my-app --template minimal
+```
+
+### Step 3: Enter the project directory
+
+```bash
+cd my-app
+```
+
+The project is now ready. If you chose the `admin` template, the initial test suite already ran during scaffolding. You can also run it manually:
+
+```bash
+npm test
+```
+
+See the [CLI and Tooling Guide](./cli-and-tooling.md) for available commands.
+
+## Project Structure Tour
+
+A scaffolded FaasJS project follows a consistent layout. Here is what you will find:
+
+```
+my-app/
+  src/
+    faas.yaml              # Runtime configuration (server root, plugins, staging overrides)
+    .faasjs/
+      types.d.ts           # Auto-generated API type declarations
+    pages/                 # Frontend pages and backend API routes
+      index.tsx            # App entry page
+      users/               # Example feature: users CRUD
+        index.tsx          # Page entry
+        api/
+          list.api.ts       # POST /pages/users/api/list
+          create.api.ts     # POST /pages/users/api/create
+          detail.api.ts     # POST /pages/users/api/detail
+          update.api.ts     # POST /pages/users/api/update
+          remove.api.ts     # POST /pages/users/api/remove
+          __tests__/        # API tests
+    types/
+      faasjs-pg.d.ts       # PostgreSQL table type declarations (declaration merging on `Tables`)
+  migrations/              # Database migration files (timestamped)
+    20250101000000_create_users.ts
+  faas.yaml                # (optional) Root-level config overrides
+  tsconfig.json            # TypeScript configuration
+  vite.config.ts           # Vite + Vitest configuration
+  package.json
+```
+
+### Key directories
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/pages/` | Frontend pages as React components and backend API routes as `.api.ts` files. Each feature gets its own subdirectory with `components/`, `hooks/`, and `api/` sub-folders. |
+| `src/types/` | Type declaration files, including `@faasjs/pg` table type augmentations. |
+| `migrations/` | Timestamped database migration files. Created and managed with the `faasjs-pg` CLI. |
+
+### Key configuration files
+
+| File | Purpose | See |
+|------|---------|-----|
+| `src/faas.yaml` | Runtime configuration: server root, base path, staging overrides, plugins | [faas.yaml Specification](../locales/en/specs/faas-yaml.md) |
+| `tsconfig.json` | TypeScript config, extends `@faasjs/types/tsconfig/*` presets | [Project Config Guide](./project-config.md) |
+| `vite.config.ts` | Vite/Vitest config, uses `viteConfig` from `@faasjs/dev` | [Project Config Guide](./project-config.md) |
+
+### Zero-Mapping routing
+
+API routes map directly to file paths under `src/`. No routing registry needed.
+
+| File | Route |
+|------|-------|
+| `src/pages/todo/api/list.api.ts` | `POST /pages/todo/api/list` |
+| `src/pages/todo/api/index.api.ts` | `POST /pages/todo/api` |
+| `src/pages/todo/api/default.api.ts` | Fallback for `/pages/todo/*` |
+
+See the [Routing Mapping Specification](../locales/en/specs/routing-mapping.md) for the full route resolution order.
+
+## Your First Feature
+
+This section walks through a complete end-to-end CRUD feature: a Todo list with a PostgreSQL table, five API endpoints, a React frontend page, and tests.
+
+### Step 1: Create a migration
+
+Create a new migration file for the `todos` table:
+
+```bash
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg new create_todos
+```
+
+This creates a file like `migrations/20250101000001_create_todos.ts`. Open it and define the table:
+
+```ts
+import type { SchemaBuilder } from '@faasjs/pg'
+
+export function up(builder: SchemaBuilder) {
+  builder.createTable('todos', (table) => {
+    table.number('id').primary()
+    table.string('title')
+    table.text('description').nullable()
+    table.boolean('completed').defaultTo(false)
+    table.timestamps()
+    table.index('title')
+  })
+}
+
+export function down(builder: SchemaBuilder) {
+  builder.dropTable('todos')
+}
+```
+
+Run the migration:
+
+```bash
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg migrate
+```
+
+See the [PG Schema and Migrations Guide](./pg-schema-and-migrations.md) for migration authoring rules.
+
+### Step 2: Update table type declarations
+
+Add the `todos` table type in `src/types/faasjs-pg.d.ts`:
+
+```ts
+import '@faasjs/pg'
+
+declare module '@faasjs/pg' {
+  interface Tables {
+    todos: {
+      id: number
+      title: string
+      description: string | null
+      completed: boolean
+      created_at: string
+      updated_at: string
+    }
+  }
+}
+```
+
+See the [PG Table Types Guide](./pg-table-types.md) for declaration merging rules.
+
+### Step 3: Create API endpoints
+
+Create five API files under `src/pages/todos/api/`. These follow the [CRUD Patterns Guide](./crud-patterns.md).
+
+#### `src/pages/todos/api/list.api.ts`
+
+```ts
+import { defineApi } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    keyword: z.string().optional(),
+    page: z.coerce.number().int().positive().default(1),
+    pageSize: z.coerce.number().int().positive().default(20),
+  }),
+  async handler({ params }) {
+    // TODO: query database with params.keyword, params.page, params.pageSize
+    return {
+      rows: [
+        { id: 1, title: 'Learn FaasJS', description: 'Build a Todo app', completed: false, created_at: '2025-01-01T00:00:00Z', updated_at: '2025-01-01T00:00:00Z' },
+      ],
+      total: 1,
+    }
+  },
+})
+```
+
+#### `src/pages/todos/api/create.api.ts`
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    title: z.string().min(1).max(200),
+    description: z.string().optional(),
+  }),
+  async handler({ params }) {
+    // TODO: insert into database and return created record
+    return {
+      id: 1,
+      title: params.title,
+      description: params.description || null,
+      completed: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+  },
+})
+```
+
+#### `src/pages/todos/api/detail.api.ts`
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+  }),
+  async handler({ params }) {
+    // TODO: fetch from database by params.id
+    const todo = { id: 1, title: 'Learn FaasJS', description: 'Build a Todo app', completed: false, created_at: '2025-01-01T00:00:00Z', updated_at: '2025-01-01T00:00:00Z' }
+
+    if (!todo) {
+      throw new HttpError({ statusCode: 404, message: 'Todo not found' })
+    }
+
+    return todo
+  },
+})
+```
+
+#### `src/pages/todos/api/update.api.ts`
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+    title: z.string().min(1).max(200).optional(),
+    description: z.string().optional(),
+    completed: z.boolean().optional(),
+  }),
+  async handler({ params }) {
+    // TODO: fetch existing todo, update, and return
+    return { id: params.id, ...params }
+  },
+})
+```
+
+#### `src/pages/todos/api/remove.api.ts`
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+  }),
+  async handler({ params }) {
+    // TODO: delete from database where id = params.id
+    return { success: true }
+  },
+})
+```
+
+See the [defineApi Guide](./define-api.md) for schema validation and error handling rules.
+
+### Step 4: Create the frontend page
+
+Create a shared items hook and a page with a table, create form, and detail view.
+
+#### `src/pages/todos/hooks/useTodoItems.ts`
+
+```tsx
+import { useConstant } from '@faasjs/react'
+import type { FormItem, TableItem, DescriptionItem } from '@faasjs/ant-design'
+
+export type TodoField = {
+  id: number
+  title: string
+  description: string | null
+  completed: boolean
+  created_at: string
+  updated_at: string
+}
+
+export function useTodoItems() {
+  return useConstant<Array<FormItem & TableItem & DescriptionItem>>(() => [
+    {
+      id: 'title',
+      title: 'Title',
+      required: true,
+      rules: [{ min: 1, max: 200 }],
+    },
+    {
+      id: 'description',
+      title: 'Description',
+      type: 'textarea',
+    },
+    {
+      id: 'completed',
+      title: 'Completed',
+      type: 'switch',
+      tableRender: (value) => (value ? 'Yes' : 'No'),
+    },
+    {
+      id: 'created_at',
+      title: 'Created At',
+      descriptionRender: (value) => new Date(value as string).toLocaleDateString(),
+    },
+  ])
+}
+```
+
+#### `src/pages/todos/index.tsx`
+
+```tsx
+import { Table, Title, useApp, Form, Description, faas } from '@faasjs/ant-design'
+import { Button, Space, Input, Modal } from 'antd'
+import { useState } from 'react'
+
+import { useTodoItems, type TodoField } from './hooks/useTodoItems'
+
+export default function TodosPage() {
+  const { message, notification, setDrawerProps, setModalProps } = useApp()
+  const [keyword, setKeyword] = useState('')
+  const [searchParams, setSearchParams] = useState<{ keyword?: string }>({})
+
+  const items = useTodoItems()
+
+  const handleDelete = (id: number, onSuccess: () => void) => {
+    setModalProps({
+      open: true,
+      title: 'Delete Todo',
+      children: 'Are you sure?',
+      onOk: async () => {
+        try {
+          await faas('/pages/todos/api/remove', { id })
+          message.success('Todo deleted')
+          setModalProps({ open: false })
+          onSuccess()
+        } catch (error: any) {
+          notification.error({ message: 'Delete failed', description: error?.message })
+        }
+      },
+    })
+  }
+
+  return (
+    <Space direction="vertical" style={{ width: '100%' }}>
+      <Title>Todo List</Title>
+
+      <Space>
+        <Input.Search
+          placeholder="Search by title"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          onSearch={() => setSearchParams({ keyword: keyword || undefined })}
+        />
+        <Button type="primary" onClick={() =>
+          setDrawerProps({
+            open: true,
+            title: 'Create Todo',
+            width: 480,
+            children: (
+              <Form
+                items={items}
+                faas={{
+                  action: '/pages/todos/api/create',
+                  onSuccess: () => {
+                    message.success('Todo created')
+                    setDrawerProps({ open: false })
+                    reload()
+                  },
+                  onError: (error) =>
+                    notification.error({ message: 'Create failed', description: error?.message }),
+                }}
+              />
+            ),
+          })
+        }>
+          Create Todo
+        </Button>
+      </Space>
+
+      <Table<TodoField>
+        rowKey="id"
+        items={[
+          ...items,
+          {
+            id: 'actions',
+            title: 'Actions',
+            tableRender: (_, row) => (
+              <Space>
+                <Button type="link" onClick={() =>
+                  setDrawerProps({
+                    open: true,
+                    title: 'Todo Detail',
+                    width: 480,
+                    children: <Description<TodoField> items={items} faasData={{ action: '/pages/todos/api/detail', params: { id: row.id } }} />,
+                  })
+                }>
+                  Detail
+                </Button>
+                <Button type="link" onClick={() =>
+                  setDrawerProps({
+                    open: true,
+                    title: 'Edit Todo',
+                    width: 480,
+                    children: (
+                      <Form
+                        initialValues={row}
+                        items={items}
+                        faas={{
+                          action: '/pages/todos/api/update',
+                          params: (values) => ({ ...values, id: row.id }),
+                          onSuccess: () => {
+                            message.success('Todo updated')
+                            setDrawerProps({ open: false })
+                            reload()
+                          },
+                          onError: (error) =>
+                            notification.error({ message: 'Update failed', description: error?.message }),
+                        }}
+                      />
+                    ),
+                  })
+                }>
+                  Edit
+                </Button>
+                <Button type="link" danger onClick={() => handleDelete(row.id, reload)}>
+                  Delete
+                </Button>
+              </Space>
+            ),
+          },
+        ]}
+        faasData={{
+          action: '/pages/todos/api/list',
+          params: searchParams,
+        }}
+      />
+    </Space>
+  )
+}
+```
+
+> The `reload()` function above is the table's reload function. In a real component you would capture it from `Table.faasData`'s render-prop or a ref pattern. See the [CRUD Patterns Guide](./crud-patterns.md) and [Ant Design Guide](./ant-design.md) for the full pattern.
+
+See the [Ant Design Guide](./ant-design.md) for page layout and component patterns, and the [React Data Fetching Guide](./react-data-fetching.md) for `useFaas`, `faas`, and lifecycle options.
+
+### Step 5: Add tests
+
+Create API tests under `src/pages/todos/api/__tests__/`. Each test uses `testApi` from `@faasjs/dev`.
+
+```ts
+// src/pages/todos/api/__tests__/create.test.ts
+import { testApi } from '@faasjs/dev'
+import { describe, expect, it } from 'vitest'
+
+import createApi from '../create.api'
+
+describe('todos/api/create', () => {
+  const handler = testApi(createApi)
+
+  it('creates a todo with valid params', async () => {
+    const response = await handler({
+      title: 'Learn FaasJS',
+      description: 'Build a Todo app',
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.data?.title).toBe('Learn FaasJS')
+  })
+
+  it('returns 400 when title is empty', async () => {
+    const response = await handler({ title: '' })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.error?.message).toContain('Invalid params')
+  })
+})
+```
+
+```ts
+// src/pages/todos/api/__tests__/list.test.ts
+import { testApi } from '@faasjs/dev'
+import { describe, expect, it } from 'vitest'
+
+import listApi from '../list.api'
+
+describe('todos/api/list', () => {
+  const handler = testApi(listApi)
+
+  it('returns paginated results', async () => {
+    const response = await handler({ page: 1, pageSize: 20 })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.data?.rows).toBeDefined()
+    expect(response.data?.total).toBeDefined()
+  })
+})
+```
+
+See the [Testing Guide](./testing.md) for testing principles, and the [CRUD Patterns Guide](./crud-patterns.md) for complete API test coverage examples.
+
+### Step 6: Run type generation and tests
+
+After creating the API files, generate type declarations so the frontend gets full type inference:
+
+```bash
+npx faas types
+```
+
+This updates `src/.faasjs/types.d.ts` with typed routes for all `.api.ts` files.
+
+Run tests to verify everything works:
+
+```bash
+vp test
+```
+
+The `admin` template also includes a users slice with the same pattern. You can copy it as a reference for your own features. See the [Application Slices Guide](./application-slices.md) for the recommended slice layout.
+
+## Key Concepts
+
+### `defineApi` and endpoint definition
+
+Every API endpoint is a file that default-exports `defineApi(...)`. The `schema` field uses Zod for input validation, and the `handler` receives typed `params`.
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+  }),
+  async handler({ params }) {
+    // params.id is typed as number
+    return { id: params.id }
+  },
+})
+```
+
+See the [defineApi Guide](./define-api.md) for detailed rules.
+
+### Zero-Mapping routing
+
+API file paths map directly to request paths — no routing configuration needed. A file at `src/pages/todos/api/list.api.ts` responds to `POST /pages/todos/api/list`. See the [Routing Mapping Specification](../locales/en/specs/routing-mapping.md) for the full resolution order.
+
+### `faas.yaml` configuration hierarchy
+
+Configuration is layered by file location and staging. A `src/faas.yaml` file sets the baseline, and deeper `faas.yaml` files can override settings for specific path scopes. Staging keys (`development`, `production`, etc.) allow environment-specific overrides.
+
+```yaml
+defaults:
+  server:
+    root: .
+    base: /api
+  plugins:
+    http:
+      type: http
+      config:
+        cookie:
+          secure: false
+```
+
+See the [faas.yaml Specification](../locales/en/specs/faas-yaml.md) for the full spec.
+
+### `@faasjs/ant-design` components
+
+The `@faasjs/ant-design` package provides business UI wrappers that handle loading, error, and data-fetching state:
+
+| Component | Purpose |
+|-----------|---------|
+| `Table.faasData` | Server-driven list with automatic re-fetch on params change |
+| `Form.faas` | Form submission with built-in loading, validation, and feedback |
+| `Description.faasData` | Detail view with loading and error states |
+| `useApp()` | Access to `message`, `notification`, `setDrawerProps`, `setModalProps` |
+
+See the [Ant Design Guide](./ant-design.md) for component patterns.
+
+### `useFaas` / `faas` data fetching
+
+| API | When to use |
+|-----|-------------|
+| `useFaas(action, params, options)` | Component-owned request state with loading, error, debounce, polling, and reload |
+| `faas(action, params)` | Imperative one-off requests (form submit, delete) |
+| `Form.faas` | Form submissions (preferred over raw `faas`) |
+
+See the [React Data Fetching Guide](./react-data-fetching.md) for lifecycle controls and patterns.
+
+### Plugin mechanism
+
+Plugins inject cross-cutting concerns (auth, tenant context, request metadata) into the request lifecycle. They are configured in `faas.yaml` under the `plugins` key and can extend the `defineApi` handler context with typed fields.
+
+See the [Plugin Specification](../locales/en/specs/plugin.md) for plugin authoring.
+
+## Development Workflow
+
+The FaasJS toolchain uses `vp` (Vite Plus) as the primary entry point for development tasks.
+
+| Command | Purpose |
+|---------|---------|
+| `vp dev` | Start the development server with hot reload |
+| `vp test` | Run all tests with Vitest |
+| `vp test <pattern>` | Run tests matching a file-name pattern |
+| `vp check --fix` | Run linting and formatting (oxlint + oxfmt) |
+| `npx faas types` | Regenerate API type declarations in `src/.faasjs/types.d.ts` |
+| `npx faasjs-pg migrate` | Run pending database migrations |
+| `npx faasjs-pg new <name>` | Create a new timestamped migration file |
+
+### Daily iteration loop
+
+1. Start the dev server: `vp dev`
+2. Edit API files (`*.api.ts`) and frontend pages (`*.tsx`)
+3. After creating, renaming, or moving `.api.ts` files, regenerate types: `npx faas types`
+4. Run focused tests: `vp test src/pages/todos/api/__tests__/list.test.ts`
+5. Before committing: `vp check --fix && vp test`
+
+### Database migrations
+
+```bash
+# Create a new migration
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg new add_due_date_to_todos
+
+# Check migration status
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg status
+
+# Apply pending migrations
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg migrate
+```
+
+See the [CLI and Tooling Guide](./cli-and-tooling.md) for all commands and troubleshooting.
+
+## Where to Go Next
+
+Now that you have a working project, explore the detailed guides:
+
+| Guide | What it covers |
+|-------|----------------|
+| [Application Slices Guide](./application-slices.md) | Vertical feature structure and recommended layout |
+| [CRUD Patterns Guide](./crud-patterns.md) | Complete CRUD implementation from API to React page |
+| [defineApi Guide](./define-api.md) | API endpoint schema, validation, and error handling |
+| [Ant Design Guide](./ant-design.md) | Page structure, routes, CRUD composition, and UI feedback |
+| [React Data Fetching Guide](./react-data-fetching.md) | `useFaas`, `faas`, lifecycle controls, polling, and retry |
+| [PG Schema and Migrations Guide](./pg-schema-and-migrations.md) | Database migration authoring rules |
+| [PG Table Types Guide](./pg-table-types.md) | Declaration merging on `Tables` for type-safe queries |
+| [PG Query Builder and Raw SQL Guide](./pg-query-builder.md) | Query building with `@faasjs/pg` |
+| [Testing Guide](./testing.md) | Testing principles and practices |
+| [React Testing Guide](./react-testing.md) | React component and request-flow testing |
+| [PG Testing Guide](./pg-testing.md) | PostgreSQL integration testing |
+| [CLI and Tooling Guide](./cli-and-tooling.md) | All CLI commands, environment variables, and troubleshooting |
+| [Project Config Guide](./project-config.md) | TypeScript, Vite, and tooling configuration |
+| [File Conventions](./file-conventions.md) | File placement and naming conventions |
+| [Jobs Guide](./jobs.md) | Background jobs with `@faasjs/jobs` |
+| [Logger Guide](./logger.md) | Logging patterns and log levels |
+| [Code Comments Guide](./code-comments.md) | JSDoc and comment conventions |
+| [faas.yaml Specification](../locales/en/specs/faas-yaml.md) | Full faas.yaml configuration reference |
+| [Routing Mapping Specification](../locales/en/specs/routing-mapping.md) | Zero-Mapping route resolution |
+| [Plugin Specification](../locales/en/specs/plugin.md) | Plugin authoring and configuration |
+| [Http Protocol Specification](../locales/en/specs/http-protocol.md) | HTTP request/response protocol details |

--- a/skills/faasjs-best-practices/guidelines/getting-started.md
+++ b/skills/faasjs-best-practices/guidelines/getting-started.md
@@ -8,7 +8,7 @@ FaasJS is a Rails-inspired, curated full-stack TypeScript framework for database
 
 Before starting, make sure your environment meets these requirements:
 
-- **Node.js** >= 20.x — FaasJS relies on modern Node features including native TypeScript module loading.
+- **Node.js** >= 24.x — FaasJS relies on modern Node features including native TypeScript module loading.
 - **npm** >= 9.x — used for dependency management and scaffolding.
 - **PostgreSQL** >= 14.x — FaasJS uses PostgreSQL as its relational data store (via `@faasjs/pg`). A running local instance or Docker container is required for database features and integration tests.
 - **Basic TypeScript knowledge** — FaasJS is TypeScript-first. You should be comfortable with types, interfaces, and module imports.
@@ -16,7 +16,7 @@ Before starting, make sure your environment meets these requirements:
 Verify your environment:
 
 ```bash
-node --version   # >= 20.x
+node --version   # >= 24.x
 npm --version    # >= 9.x
 psql --version   # >= 14.x
 ```

--- a/skills/faasjs-best-practices/locales/zh/guidelines/cli-and-tooling.md
+++ b/skills/faasjs-best-practices/locales/zh/guidelines/cli-and-tooling.md
@@ -1,0 +1,239 @@
+# CLI and Tooling 指南
+
+当你在运行 CLI 命令、排查命令错误或为任务选择合适的工具时，请使用这份指南。它是 FaasJS 工具链的快速参考，帮助减少命令执行错误。
+
+## 默认工作流
+
+1. 在运行任何 FaasJS 命令之前，先执行 `npm install` 安装依赖。
+2. 在创建、重命名或移动 `.api.ts` 文件后，运行 `faas types` 重新生成类型声明。
+3. 在提交前使用 `vp check --fix` 进行代码格式化和 lint 检查。
+4. 使用 `vp test` 作为默认测试运行器；可使用 `vp test <pattern>` 进行针对性运行。
+5. 当有迁移待执行时，通过 `faasjs-pg migrate` 运行数据库迁移。
+6. 当命令不可用时，回退到 `npx <command>`，并确认 `node_modules` 目录存在。
+
+## faas CLI
+
+由 `@faasjs/dev` 提供 `faas` 二进制命令 (`faas.mjs`)。它有两个子命令：`run` 和 `types`。
+
+| 命令 | 说明 |
+|---|---|
+| `faas run <file>` | 使用预加载的 FaasJS Node 模块 hooks 运行 TypeScript 文件 |
+| `faas run <file> --root <path>` | 指定项目根目录来解析 `<file>`（默认：`process.cwd()`） |
+| `faas types` | 生成 API 类型声明到 `src/.faasjs/types.d.ts` |
+| `faas types --root <path>` | 指定类型生成的项目根目录 |
+
+全局选项：
+- `-h, --help` — 显示帮助文本。
+- `-v, --version` — 打印 `@faasjs/dev` 版本。
+
+> **运行细节**：`faas run` 解析 `@faasjs/node-utils/register-hooks` 并使用 `--import` 启动一个子 Node 进程，使目标脚本获得正常的 `process.argv`。
+
+> **类型生成细节**：`faas types` 扫描 `src/` 目录下的 `.api.ts` 文件，将文件名转换为路由，并写入 `src/.faasjs/types.d.ts`。它会跳过 `.faasjs` 和 `node_modules` 目录。只有 `.api.ts` 文件和 `faas.yaml` 的变化会触发类型重新生成（参见 `@faasjs/dev` 中的 `isTypegenInputFile`）。
+
+## Vite Plus / vp
+
+由 `vite-plus` 包提供。它是在 Vite 和 Vitest 之上构建的开发与构建工具层。
+
+| 命令 | 说明 |
+|---|---|
+| `vp check --fix` | 通过 oxlint 和 oxfmt 运行代码检查（lint）和格式化修复 |
+| `vp test` | 使用 Vitest 运行所有测试 |
+| `vp test <pattern>` | 运行匹配文件名模式的测试 |
+| `vp test --watch` | 以 watch 模式运行测试 |
+| `vp dev` | 启动开发服务器 |
+
+常用组合：
+```bash
+# 在交付前运行检查和测试
+vp check --fix && vp test
+
+# 运行特定的测试文件
+vp test src/pages/users/api/__tests__/list.test.ts
+
+# 按模式匹配并 watch 运行测试
+vp test list --watch
+
+# 指定日志级别运行测试
+FaasLog=info vp test
+
+# 在自定义端口启动开发服务器（在 vite.config.ts 中配置）
+vp dev
+```
+
+## 项目创建
+
+使用 `create-faas-app` 来搭建新项目。
+
+```bash
+npx create-faas-app --name <project-name>
+```
+
+选项：
+- `--name <name>` — 项目文件夹名称。
+- `--template <template>` — 模板名称（默认：`admin`）。
+
+可用模板：
+- `admin`（默认）— 推荐的 React + Ant Design + PostgreSQL 起步模板。
+- `minimal` — 更轻量的 React 起步模板。
+
+搭建完成后，脚本会自动执行：
+1. `npm install` — 安装依赖。
+2. `npm run test` — 运行初始测试套件以验证配置。
+
+创建后手动运行这些步骤：
+```bash
+cd <project-name>
+npm install
+npx faas types
+```
+
+## 迁移命令
+
+由 `@faasjs/pg` 提供 `faasjs-pg` 二进制命令。
+
+| 命令 | 说明 |
+|---|---|
+| `faasjs-pg new <name>` | 在 `migrations/` 中创建新的带时间戳的迁移文件 |
+| `faasjs-pg status` | 显示所有迁移的状态 |
+| `faasjs-pg migrate` | 运行所有待执行的迁移 |
+| `faasjs-pg up` | 运行下一个待执行的迁移 |
+| `faasjs-pg down` | 回滚最近一次已应用的迁移 |
+
+要求：
+- `status`、`migrate`、`up` 和 `down` 命令需要设置 `DATABASE_URL` 环境变量。
+- 迁移文件默认存放在 `./migrations` 目录下。
+- 迁移文件命名规范：`<timestamp>-<name>.ts`（由 `faasjs-pg new` 自动生成）。
+- 迁移编写规则参见 [PG Schema and Migrations 指南](./pg-schema-and-migrations.md)。
+
+示例：
+```bash
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg migrate
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg new add_users_table
+```
+
+## 类型生成工作流
+
+保持类型声明与 API 路由同步：
+
+1. 在**创建**、**重命名**或**移动** `.api.ts` 文件后，运行：
+
+   ```bash
+   npx faas types
+   ```
+
+2. 生成的文件写入到 `src/.faasjs/types.d.ts`。
+
+3. 输出结果通过模块扩展（module augmentation）在 `@faasjs/types` 上声明 `FaasActions` 接口，为每个路由提供类型化的 `InferFaasAction` 和 `InferFaasApi`。
+
+4. `faas types` 是幂等的：它会将生成的内容与现有文件进行比较，仅在内容有变化时才会写入。
+
+5. 如需在代码中生成类型（例如在脚本中），可以从 `@faasjs/dev` 导入 `generateFaasTypes`：
+
+   ```ts
+   import { generateFaasTypes } from '@faasjs/dev'
+
+   const result = await generateFaasTypes({ root: process.cwd() })
+   console.log(result.output, result.routeCount)
+   ```
+
+## 测试命令
+
+| 命令 | 说明 |
+|---|---|
+| `vp test` | 运行完整的测试套件 |
+| `vp test <pattern>` | 运行匹配文件名模式的测试（例如 `vp test list` 会运行 `*list*`） |
+| `vp test --watch` | 文件变更时重新运行测试 |
+| `FaasLog=info vp test` | 以指定的日志详细级别运行测试 |
+
+测试原则参见 [测试指南](./testing.md)，Vitest 项目配置参见 [项目配置指南](./project-config.md)。
+
+## 常见命令错误及恢复
+
+### `faas: command not found`
+- **检查**：`npx faas --version` 或 `npx @faasjs/dev --version`
+- **恢复**：确保已安装 `@faasjs/dev`：`npm install @faasjs/dev`
+- **根本原因**：`faas` 二进制命令定义在 `@faasjs/dev` 中，不是全局命令。
+
+### `vp: command not found`
+- **检查**：`npx vp --version`
+- **恢复**：确保已安装 `vite-plus`：`npm install vite-plus`
+- **根本原因**：`vp` 二进制命令由 `vite-plus` 提供。
+
+### `faas types` 失败
+- **检查**：`src/faas.yaml` 是否存在？YAML 是否有效？
+- **检查**：`src/` 目录下是否至少有一个 `.api.ts` 文件？
+- **恢复**：如果在项目根目录之外，运行 `npx faas types --root .`。
+- **参见**：[faas.yaml 规范](../locales/en/specs/faas-yaml.md)
+
+### `faasjs-pg` 命令失败
+- **检查**：是否设置了 `DATABASE_URL`？`echo $DATABASE_URL`
+- **检查**：数据库是否可达？`psql $DATABASE_URL -c 'SELECT 1'`
+- **恢复**：在命令前添加 `DATABASE_URL=postgres://...` 或在 `.env` 中设置。
+- **根本原因**：除 `new` 之外的所有 `faasjs-pg` 命令都需要活动的数据库连接。
+
+### 测试失败
+- **检查**：依赖是否已安装？`npm ls @faasjs/dev vite-plus vitest`
+- **检查**：项目是否有有效的 `vitest.config.ts` 或 `vite.config.ts`？
+- **检查**：集成测试所需的环境变量（例如 `DATABASE_URL`）是否可用？
+- **恢复**：先运行一个针对性测试：`vp test src/specific/test.ts`
+- **参见**：Vite/Vitest 配置参见 [项目配置指南](./project-config.md)。
+
+## 环境变量与配置
+
+### FaasJS 运行时
+| 变量 | 说明 | 默认值 |
+|---|---|---|
+| `FaasEnv` | `faas.yaml` 配置加载所使用的活动环境名称 | `development` |
+| `FaasLog` | 最低日志级别（`debug`、`info`、`warn`、`error`） | `info` |
+| `FaasLogMode` | 日志输出格式（`plain`、`pretty`） | 自动检测 |
+| `FaasLogSize` | 非错误长日志的截断阈值（字节） | 平台相关 |
+| `FaasLogTransport` | 启用或禁用共享日志传输转发 | `true` |
+
+### 数据库
+| 变量 | 说明 | 使用者 |
+|---|---|---|
+| `DATABASE_URL` | PostgreSQL 连接字符串 | `faasjs-pg` CLI、`@faasjs/pg` 客户端启动、`@faasjs/pg-dev` 测试插件 |
+
+### 使用示例
+```bash
+# 使用 debug 日志运行测试
+FaasLog=debug vp test
+
+# 针对特定数据库运行迁移
+DATABASE_URL=postgres://user:pass@localhost:5432/myapp npx faasjs-pg migrate
+
+# 为特定项目根目录运行类型生成
+npx faas types --root /path/to/project
+```
+
+## 关键配置文件
+
+| 文件 | 用途 |
+|---|---|
+| `faas.yaml` | 运行时配置：server root、base path、环境覆盖、插件 |
+| `tsconfig.json` | TypeScript 配置，继承 `@faasjs/types/tsconfig/*` 预设 |
+| `vite.config.ts` | Vite/Vitest 配置，使用 `@faasjs/dev` 的 `viteConfig` |
+| `.env` | 本地开发的环境变量覆盖 |
+
+## 规则
+
+1. **每次修改 `.api.ts` 后运行 `faas types`。** 创建、重命名或移动 API 文件后如果不重新生成类型，会导致调用方出现类型错误。
+2. **优先使用 `vp check --fix` 而非手动格式化。** 它通过 vite-plus 共享配置使用 oxlint 和 oxfmt。
+3. **优先使用 `vp test` 而非直接调用 `vitest`。** 它使用项目的 `vite.config.ts`，其中包含所有必要的插件和别名。
+4. **当二进制命令未全局安装时，使用 `npx`。** `faas` 和 `vp` 都是项目 `node_modules` 的本地命令。
+5. **运行 `faasjs-pg` 命令前先设置 `DATABASE_URL`。** 除 `new` 之外的所有操作都需要活动的数据库连接。
+6. **保持迁移时间戳唯一。** `faasjs-pg new` 命令使用 ISO 时间戳；不要手动编辑文件名以避免顺序冲突。
+7. **不要手动编辑 `src/.faasjs/types.d.ts`。** 它由 `faas types` 重新生成，任何手动修改都会被覆盖。
+8. **使用 `FaasLog` 详细级别进行调试，而不是修改日志调用点。** 日志运行时会遵循 `FaasLog` 的设置。
+
+## 评审清单
+
+- `.api.ts` 变更后已运行 `faas types`（或有记录的原因说明）
+- `faas.yaml` 是有效的 YAML，并遵循 [faas.yaml 规范](../locales/en/specs/faas-yaml.md)
+- 提交前 `vp check --fix` 通过
+- `vp test` 通过（或记录了阻塞原因 + 已运行的小范围验证）
+- 运行 `faasjs-pg` 迁移命令前已设置 `DATABASE_URL`
+- 迁移文件在 `migrations/` 目录下，并遵循时间戳命名规范
+- `src/.faasjs/types.d.ts` 未经手动编辑
+- 当二进制命令未全局安装时，使用了 `npx` 前缀
+- 环境变量（`FaasEnv`、`FaasLog`、`DATABASE_URL`）按项目需要进行文档记录或已明确

--- a/skills/faasjs-best-practices/locales/zh/guidelines/crud-patterns.md
+++ b/skills/faasjs-best-practices/locales/zh/guidelines/crud-patterns.md
@@ -1,0 +1,730 @@
+# CRUD Patterns 指南
+
+当你在 FaasJS 应用中实现或评审标准 CRUD 功能（列表、详情、创建、更新、删除）时，请使用这份指南。它涵盖了从 API endpoint 到 React 页面的完整垂直切片。
+
+更深层的规则请参考[应用切片指南](./application-slices.md)、[Ant Design 指南](./ant-design.md)、[defineApi 指南](./define-api.md)和 [React 数据请求指南](./react-data-fetching.md)。本指南聚焦于如何将这些模式组合成一个完整的 CRUD 周期。
+
+## 默认工作流
+
+1. 将业务字段建模为共享的 `items` metadata，放在 `use<Feature>Items` hook 中。
+2. 创建五个 API 文件：`list`、`detail`、`create`、`update`、`remove`。
+3. 使用 `Table.faasData` 构建列表页面，包含搜索/筛选控件和操作列。
+4. 在抽屉中使用 `Description.faasData` 添加详情视图。
+5. 添加创建/更新表单，复用相同的 `items`，并使用 `Form.faas`。
+6. 使用模态确认弹窗添加删除功能。
+7. 接入 mutation 反馈（`message.success`、`notification.error`）和表层刷新/关闭。
+8. 使用 `testApi` 添加 API 测试，覆盖成功、校验和错误路径。
+9. 使用 `setMock` 添加 React 测试，覆盖加载、渲染和 mutation 流程。
+
+## 快速参考表
+
+### API Endpoint 映射
+
+| 操作   | API 文件                          | 路由                                         | 方法 | 参数                                       |
+|--------|-----------------------------------|----------------------------------------------|------|--------------------------------------------|
+| 列表   | `api/list.api.ts`                 | `POST /pages/<feature>/api/list`             | post | 筛选条件、分页                             |
+| 详情   | `api/detail.api.ts`               | `POST /pages/<feature>/api/detail`           | post | `{ id }`                                   |
+| 创建   | `api/create.api.ts`               | `POST /pages/<feature>/api/create`           | post | 业务字段                                   |
+| 更新   | `api/update.api.ts`               | `POST /pages/<feature>/api/update`           | post | `{ id, ...fields }`                        |
+| 删除   | `api/remove.api.ts`               | `POST /pages/<feature>/api/remove`           | post | `{ id }`                                   |
+
+### 文件命名约定
+
+| 层        | 约定                                 | 示例                                    |
+|-----------|--------------------------------------|-----------------------------------------|
+| 页面入口  | `pages/<feature>/index.tsx`          | `pages/users/index.tsx`                 |
+| 组件      | `pages/<feature>/components/*.tsx`   | `pages/users/components/UserTable.tsx`  |
+| Hooks     | `pages/<feature>/hooks/*.ts`         | `pages/users/hooks/useUserItems.ts`     |
+| APIs      | `pages/<feature>/api/*.api.ts`       | `pages/users/api/list.api.ts`           |
+| API 测试  | `pages/<feature>/api/__tests__/*.test.ts` | `pages/users/api/__tests__/list.test.ts` |
+
+## 共享 Items 模式
+
+`items` 数组是 `Form`、`Table` 和 `Description` 中业务字段的唯一真实来源。每个 item 描述一个字段：其 id、标签、输入类型、校验规则以及可选的各表层专属渲染器。
+
+将 items 定义在 `use<Feature>Items` hook 中，使其保持内聚且可复用。
+
+```tsx
+import { useConstant } from '@faasjs/react'
+import type { FormItem, TableItem, DescriptionItem } from '@faasjs/ant-design'
+
+export type UserField = {
+  id: number
+  name: string
+  email: string
+  role: string
+  created_at: string
+}
+
+export function useUserItems() {
+  return useConstant<Array<FormItem & TableItem & DescriptionItem>>(() => [
+    {
+      id: 'name',
+      title: 'Name',
+      required: true,
+      rules: [{ min: 1, max: 100 }],
+      tableRender: (value) => <a>{value}</a>,
+    },
+    {
+      id: 'email',
+      title: 'Email',
+      required: true,
+      rules: [{ type: 'email' }],
+    },
+    {
+      id: 'role',
+      title: 'Role',
+      required: true,
+      type: 'select',
+      options: [
+        { label: 'Admin', value: 'admin' },
+        { label: 'Editor', value: 'editor' },
+        { label: 'Viewer', value: 'viewer' },
+      ],
+    },
+    {
+      id: 'created_at',
+      title: 'Created At',
+      descriptionRender: (value) => new Date(value as string).toLocaleDateString(),
+    },
+  ])
+}
+```
+
+**Items 规则：**
+
+- 将 items 放在 `useConstant` 中，使数组引用在重渲染间保持稳定。
+- 仅在展示形式确实因表层不同时才添加 `tableRender`、`descriptionRender` 或 `formRender`。
+- 对于只出现在一个表层上的字段（如操作列），在消费组件中内联添加，不要污染共享 items。
+- 对重复的自定义字段行为使用 `extendTypes`（参见 [Ant Design 指南](./ant-design.md#core-patterns)）。
+
+## 列表页面模式
+
+使用 `Table.faasData` 进行服务端驱动的列表请求。在表格上方添加一行搜索/筛选控件，以及用于详情/编辑/删除的操作列。
+
+```tsx
+import { Table, Title, useApp } from '@faasjs/ant-design'
+import { Input, Button, Space } from 'antd'
+import { useState } from 'react'
+
+import { UserActions } from './components/UserActions'
+import { useUserItems, type UserField } from './hooks/useUserItems'
+
+export default function UsersPage() {
+  const { setDrawerProps } = useApp()
+  const [keyword, setKeyword] = useState('')
+  const [searchParams, setSearchParams] = useState<{ keyword?: string }>({})
+
+  const items = useUserItems()
+
+  return (
+    <Space direction="vertical" style={{ width: '100%' }}>
+      <Title>Users</Title>
+
+      <Space>
+        <Input.Search
+          placeholder="Search by name or email"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          onSearch={() => setSearchParams({ keyword: keyword || undefined })}
+        />
+        <Button type="primary" onClick={() =>
+          setDrawerProps({
+            open: true,
+            title: 'Create User',
+            width: 720,
+            children: <UserForm onSuccess={() => reload()} />,
+          })
+        }>
+          Create User
+        </Button>
+      </Space>
+
+      <Table<UserField>
+        rowKey="id"
+        items={[
+          ...items,
+          {
+            id: 'actions',
+            title: 'Actions',
+            tableRender: (_, row) => (
+              <UserActions row={row} onSuccess={() => reload()} />
+            ),
+          },
+        ]}
+        faasData={{
+          action: '/pages/users/api/list',
+          params: searchParams,
+        }}
+      />
+    </Space>
+  )
+}
+```
+
+### 列表 API
+
+```ts
+import { defineApi } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    keyword: z.string().optional(),
+    page: z.coerce.number().int().positive().default(1),
+    pageSize: z.coerce.number().int().positive().default(20),
+  }),
+  async handler({ params }) {
+    // Query database with params.keyword, params.page, params.pageSize
+    return {
+      rows: [
+        { id: 1, name: 'Alice', email: 'alice@example.com', role: 'admin', created_at: '2025-01-01' },
+      ],
+      total: 1,
+    }
+  },
+})
+```
+
+### 搜索 / 筛选触发
+
+- 使用 `setSearchParams` 触发 `Table.faasData` 重新请求。当 `faasData.params` 变化时，表格会自动重新请求。
+- 通过 `useFaas` 生命周期使用 `debounce`，而非自定义定时器（参见 [React 数据请求指南](./react-data-fetching.md)）。
+- 将 `keyword` 保持为输入框的本地状态，仅在提交搜索时推入 `searchParams`。
+
+## 详情模式
+
+使用 `Description.faasData` 进行详情请求。在抽屉中打开以保持列表上下文可见。
+
+```tsx
+import { Description, useApp } from '@faasjs/ant-design'
+
+import { useUserItems, type UserField } from '../hooks/useUserItems'
+
+export function UserDetail(props: { id: number }) {
+  const items = useUserItems()
+
+  return (
+    <Description<UserField>
+      items={items}
+      faasData={{
+        action: '/pages/users/api/detail',
+        params: { id: props.id },
+      }}
+    />
+  )
+}
+```
+
+### 详情 API
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+  }),
+  async handler({ params }) {
+    // Fetch from database by params.id
+    const user = { id: 1, name: 'Alice', email: 'alice@example.com', role: 'admin', created_at: '2025-01-01' }
+
+    if (!user) {
+      throw new HttpError({ statusCode: 404, message: 'User not found' })
+    }
+
+    return user
+  },
+})
+```
+
+**详情规则：**
+
+- 复用 `use<Feature>Items` 中相同的 `items`。
+- 对于详情中不同的字段，在 item 上使用 `descriptionRender`。
+- 保持详情 API 响应结构与 item 字段 id 对齐。
+
+## 创建表单模式
+
+使用 `Form.faas` 进行表单提交，内置加载、校验、反馈和错误处理。
+
+```tsx
+import { Form, useApp } from '@faasjs/ant-design'
+
+import { useUserItems } from '../hooks/useUserItems'
+
+export function UserForm(props: { onSuccess?: () => void }) {
+  const { message, notification, setDrawerProps } = useApp()
+  const items = useUserItems()
+
+  return (
+    <Form
+      items={items}
+      faas={{
+        action: '/pages/users/api/create',
+        onSuccess: () => {
+          message.success('User created')
+          setDrawerProps({ open: false })
+          props.onSuccess?.()
+        },
+        onError: (error) =>
+          notification.error({
+            message: 'Create failed',
+            description: error?.message,
+          }),
+      }}
+    />
+  )
+}
+```
+
+### 创建 API
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    name: z.string().min(1).max(100),
+    email: z.string().email(),
+    role: z.enum(['admin', 'editor', 'viewer']),
+  }),
+  async handler({ params }) {
+    // Check for duplicates
+    if (/* email already exists */) {
+      throw new HttpError({ statusCode: 409, message: 'Email already exists' })
+    }
+
+    // Insert into database and return created record
+    return {
+      id: 1,
+      name: params.name,
+      email: params.email,
+      role: params.role,
+      created_at: new Date().toISOString(),
+    }
+  },
+})
+```
+
+**创建表单规则：**
+
+- `Form.faas` 会自动处理按钮加载、校验和错误反馈。
+- 成功反馈使用 `message.success`，失败反馈使用 `notification.error`。
+- 成功后通过 `setDrawerProps({ open: false })` 关闭抽屉/弹窗。
+- 调用 `props.onSuccess?.()` 以便父组件刷新列表。
+
+## 更新表单模式
+
+复用同一个 `UserForm` 组件，通过传入 `initialValues` 并切换 API action 实现。表单通过详情请求预填数据。
+
+```tsx
+import { Form, useApp } from '@faasjs/ant-design'
+
+import { useUserItems } from '../hooks/useUserItems'
+
+export function UserForm(props: {
+  id?: number
+  initialValues?: Record<string, any>
+  onSuccess?: () => void
+}) {
+  const { message, notification, setDrawerProps } = useApp()
+  const items = useUserItems()
+
+  return (
+    <Form
+      initialValues={props.initialValues}
+      items={items}
+      faas={{
+        action: props.id ? '/pages/users/api/update' : '/pages/users/api/create',
+        params: (values) => ({ ...values, ...(props.id ? { id: props.id } : {}) }),
+        onSuccess: () => {
+          message.success(props.id ? 'User updated' : 'User created')
+          setDrawerProps({ open: false })
+          props.onSuccess?.()
+        },
+        onError: (error) =>
+          notification.error({
+            message: props.id ? 'Update failed' : 'Create failed',
+            description: error?.message,
+          }),
+      }}
+    />
+  )
+}
+```
+
+### 更新 API
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+    name: z.string().min(1).max(100).optional(),
+    email: z.string().email().optional(),
+    role: z.enum(['admin', 'editor', 'viewer']).optional(),
+  }),
+  async handler({ params }) {
+    const existing = { id: 1 } // Fetch from database
+
+    if (!existing) {
+      throw new HttpError({ statusCode: 404, message: 'User not found' })
+    }
+
+    // Update database where id = params.id
+    return { id: params.id, ...params }
+  },
+})
+```
+
+**更新表单规则：**
+
+- 对创建和更新使用同一个 `UserForm` 组件——`id` 属性决定模式。
+- 在打开抽屉的页面/组件中获取当前值，然后作为 `initialValues` 传入。
+- 将更新 API 字段设为可选（`z.string().optional()`），以支持部分更新。
+- 使用 `Form.faas` 的 `params` 函数根据更新操作有条件地包含 `id`。
+
+## 删除模式
+
+对破坏性操作使用模态确认弹窗。在 `onOk` 处理程序中命令式调用 `faas`。
+
+```tsx
+import { Button, Space } from 'antd'
+import { faas, useApp } from '@faasjs/ant-design'
+
+export function UserActions(props: { row: { id: number }; onSuccess?: () => void }) {
+  const { message, notification, setModalProps } = useApp()
+
+  const handleDelete = () => {
+    setModalProps({
+      open: true,
+      title: 'Delete User',
+      children: 'Are you sure you want to delete this user? This action cannot be undone.',
+      onOk: async () => {
+        try {
+          await faas('/pages/users/api/remove', { id: props.row.id })
+          message.success('User deleted')
+          setModalProps({ open: false })
+          props.onSuccess?.()
+        } catch (error: any) {
+          notification.error({
+            message: 'Delete failed',
+            description: error?.message,
+          })
+        }
+      },
+    })
+  }
+
+  const handleEdit = () => {
+    // Open drawer with UserForm and initialValues from props.row
+  }
+
+  const handleDetail = () => {
+    // Open drawer with UserDetail
+  }
+
+  return (
+    <Space>
+      <Button type="link" onClick={handleDetail}>Detail</Button>
+      <Button type="link" onClick={handleEdit}>Edit</Button>
+      <Button type="link" danger onClick={handleDelete}>Delete</Button>
+    </Space>
+  )
+}
+```
+
+### 删除 API
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+  }),
+  async handler({ params }) {
+    const existing = { id: 1 } // Fetch from database
+
+    if (!existing) {
+      throw new HttpError({ statusCode: 404, message: 'User not found' })
+    }
+
+    // Delete from database where id = params.id
+    return { success: true }
+  },
+})
+```
+
+**删除规则：**
+
+- 使用 `useApp()` 中的 `setModalProps` 进行模态确认。
+- 在 `onOk` 处理程序内部命令式调用 `faas`——而不是 `Form.faas`。
+- 始终先获取记录，未找到时返回 `404`。
+- 成功后关闭弹窗，显示 `message.success`，并调用 `onSuccess` 刷新父组件。
+
+## 完整 CRUD 切片布局参考
+
+### 目录结构
+
+```
+src/pages/users/
+  index.tsx                          # 页面入口：组合 UserTable、创建按钮
+  components/
+    UserTable.tsx                    # 带 faasData、搜索、操作列的表格
+    UserForm.tsx                     # 创建/更新表单（id 属性切换模式）
+    UserDetail.tsx                   # 带 faasData 的 Description
+    UserActions.tsx                  # 详情 / 编辑 / 删除按钮
+  hooks/
+    useUserItems.ts                  # 共享 items metadata
+  api/
+    list.api.ts                      # POST /pages/users/api/list
+    detail.api.ts                    # POST /pages/users/api/detail
+    create.api.ts                    # POST /pages/users/api/create
+    update.api.ts                    # POST /pages/users/api/update
+    remove.api.ts                    # POST /pages/users/api/remove
+    __tests__/
+      list.test.ts                   # list 的 testApi
+      detail.test.ts                 # detail 的 testApi
+      create.test.ts                 # create 的 testApi
+      update.test.ts                 # update 的 testApi
+      remove.test.ts                 # remove 的 testApi
+```
+
+### 文件数量与职责
+
+| 文件                        | 行数（约） | 职责                                      |
+|-----------------------------|------------|-------------------------------------------|
+| `index.tsx`                 | 30-60      | 页面入口、布局、组合组件                   |
+| `UserTable.tsx`             | 40-80      | 表格、搜索、筛选、操作列                   |
+| `UserForm.tsx`              | 30-60      | 表单项、faas 配置、反馈                    |
+| `UserDetail.tsx`            | 15-30      | 带 faasData 的 Description                 |
+| `UserActions.tsx`           | 40-70      | 详情/编辑/删除按钮、模态确认               |
+| `useUserItems.ts`           | 30-60      | 共享 items metadata                        |
+| 每个 `.api.ts`              | 15-40      | Schema、handler、DB 查询                   |
+| 每个 API 测试               | 20-50      | testApi、成功/错误路径                     |
+
+## 测试 CRUD Endpoint
+
+使用 `@faasjs/dev` 中的 `testApi` 测试每个 endpoint。覆盖成功、校验失败和预期的业务错误。
+
+```ts
+import { testApi } from '@faasjs/dev'
+import { describe, expect, it } from 'vitest'
+
+import createApi from '../create.api'
+import listApi from '../list.api'
+import detailApi from '../detail.api'
+import updateApi from '../update.api'
+import removeApi from '../remove.api'
+
+describe('users/api/create', () => {
+  const handler = testApi(createApi)
+
+  it('creates a user with valid params', async () => {
+    const response = await handler({
+      name: 'Alice',
+      email: 'alice@example.com',
+      role: 'admin',
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.data?.name).toBe('Alice')
+    expect(response.data?.id).toBeGreaterThan(0)
+  })
+
+  it('returns 400 when email is invalid', async () => {
+    const response = await handler({
+      name: 'Alice',
+      email: 'not-an-email',
+      role: 'admin',
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.error?.message).toContain('Invalid params')
+  })
+
+  it('returns 409 when email already exists', async () => {
+    const response = await handler({
+      name: 'Alice',
+      email: 'existing@example.com',
+      role: 'admin',
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(response.error?.message).toBe('Email already exists')
+  })
+})
+
+describe('users/api/list', () => {
+  const handler = testApi(listApi)
+
+  it('returns paginated results', async () => {
+    const response = await handler({ page: 1, pageSize: 20 })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.data?.rows).toBeDefined()
+    expect(response.data?.total).toBeDefined()
+    expect(Array.isArray(response.data?.rows)).toBe(true)
+  })
+
+  it('filters by keyword', async () => {
+    const response = await handler({ keyword: 'Alice', page: 1, pageSize: 20 })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.data?.rows).toBeDefined()
+  })
+})
+
+describe('users/api/detail', () => {
+  const handler = testApi(detailApi)
+
+  it('returns user detail', async () => {
+    const response = await handler({ id: 1 })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.data?.id).toBe(1)
+  })
+
+  it('returns 404 for non-existent user', async () => {
+    const response = await handler({ id: 999 })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.error?.message).toBe('User not found')
+  })
+})
+
+describe('users/api/update', () => {
+  const handler = testApi(updateApi)
+
+  it('updates a user', async () => {
+    const response = await handler({ id: 1, name: 'Alice Updated' })
+
+    expect(response.statusCode).toBe(200)
+  })
+
+  it('returns 404 for non-existent user', async () => {
+    const response = await handler({ id: 999, name: 'Ghost' })
+
+    expect(response.statusCode).toBe(404)
+  })
+})
+
+describe('users/api/remove', () => {
+  const handler = testApi(removeApi)
+
+  it('deletes a user', async () => {
+    const response = await handler({ id: 1 })
+
+    expect(response.statusCode).toBe(200)
+  })
+
+  it('returns 404 for non-existent user', async () => {
+    const response = await handler({ id: 999 })
+
+    expect(response.statusCode).toBe(404)
+  })
+})
+```
+
+**CRUD 测试规则：**
+
+- 遵循共享的[测试指南](./testing.md)和 [defineApi 指南](./define-api.md)。
+- 对每个 endpoint 测试：成功路径、校验失败（400）和业务错误（404、409）。
+- 使用 `testApi(api)` 获取类型化的 handler。
+- 同时断言 `statusCode` 和 `data`/`error` 的结构。
+- 将测试放在 API 文件旁边的 `api/__tests__/` 下。
+
+## Agent 效率技巧
+
+以下模式可帮助 AI coding agent 以 2-3 倍速度生成完整的 CRUD 功能。
+
+### 1. 从 items 开始
+
+```text
+Prompt: "Create a `useProductItems` hook with fields: name (required), price (required, positive number), category (select with 3 options), description (textarea), status (select). Store in pages/products/hooks/useProductItems.ts"
+```
+
+Items 是基础。一旦 items 存在，agent 就能一致地推导出 `Table`、`Form` 和 `Description`。
+
+### 2. 一次性生成五个 API
+
+```text
+Prompt: "Create 5 API files for products CRUD under pages/products/api/: list, detail, create, update, remove. Follow the defineApi guide. Each should have a Zod schema and handler."
+```
+
+五个小的 `.api.ts` 文件一起生成比逐个生成更快，而且 agent 可以保持 schema 的一致性。
+
+### 3. 复制粘贴组合表单
+
+带有 `id` 模式切换（创建 vs 更新）的 `UserForm` 模式是可复用的。生成一个组合表单，而不是分开的创建/更新组件。
+
+### 4. 一次性生成列表 + 抽屉连线
+
+```text
+Prompt: "Create pages/products/index.tsx with a Table.faasData list, search button, create button that opens a drawer with ProductForm, and an actions column with detail/edit/delete. Use the shared items from useProductItems."
+```
+
+一个提示覆盖了页面入口、表格、抽屉连线和操作列。
+
+### 5. 批量 API 测试
+
+```text
+Prompt: "Create test files for all 5 product APIs under pages/products/api/__tests__/. Each test should cover success and 400/404/409 paths where applicable."
+```
+
+一个提示以一致的模式生成所有测试。
+
+### 6. 对新功能使用切片模板
+
+当开始一个新的 CRUD 功能时，先创建完整的目录结构：
+
+```text
+Prompt: "Create a full CRUD slice for orders under pages/orders/. Include: index.tsx, components/ (OrderTable, OrderForm, OrderDetail, OrderActions), hooks/useOrderItems, api/ (list, detail, create, update, remove), and api/__tests__/ for all 5 endpoints."
+```
+
+## 规则
+
+1. 使用共享的 `items`（放在 `use<Feature>Items` hook 中）作为 `Form`、`Table` 和 `Description` 中业务字段的唯一真实来源。
+2. 使用 CRUD 操作名（`list`、`detail`、`create`、`update`、`remove`）命名 API 文件，并放在 `<feature>/api/` 下。
+3. 创建/更新提交使用 `Form.faas`——它会自动处理加载、校验和错误反馈。
+4. 列表请求使用 `Table.faasData`——它会自动处理加载、错误和参数变化时的重新请求。
+5. 详情请求使用 `Description.faasData`。
+6. 使用组合的 `UserForm` 组件，通过 `id` 属性在创建和更新模式之间切换。
+7. 删除和其他一次性 mutation 使用命令式 `faas`。
+8. 每次 mutation 后关闭覆盖层并刷新受影响的表层。
+9. 成功反馈使用 `message.success`，失败反馈使用 `notification.error`。
+10. 在 detail、update 和 remove endpoint 中始终先获取资源，未找到时返回 `404`。
+11. 在 create/update endpoint 中检查重复，冲突时返回 `409`。
+12. 将 API 测试放在 `api/__tests__/` 下，使用 `@faasjs/dev` 的 `testApi`。
+13. 将 `items` 放在 `useConstant` 中，使数组引用在重渲染间保持稳定。
+14. 操作列在 `Table` items 中内联添加，而不是在共享 items 中。
+15. 使用 `useApp()` 中的 `setDrawerProps` 进行上下文内的创建/编辑/详情覆盖层。
+16. 使用 `useApp()` 中的 `setModalProps` 进行破坏性确认弹窗。
+
+## 评审清单
+
+- [ ] 存在共享的 `use<Feature>Items` hook，包含所有业务字段
+- [ ] 存在五个 API 文件：`list.api.ts`、`detail.api.ts`、`create.api.ts`、`update.api.ts`、`remove.api.ts`
+- [ ] 每个 API 在 `defineApi` 中内联定义了 Zod schema
+- [ ] 列表 API 返回 `{ rows, total }` 结构
+- [ ] 详情/更新/删除 API 检查存在性，未找到时返回 `404`
+- [ ] 创建/更新 API 检查重复，冲突时返回 `409`
+- [ ] `Table.faasData` 驱动列表，带搜索/筛选参数
+- [ ] `Description.faasData` 驱动详情视图
+- [ ] `Form.faas` 驱动创建/更新，带基于 `id` 的模式切换
+- [ ] `faas` + 模态确认弹窗驱动删除
+- [ ] Mutation 提供反馈（`message.success`、`notification.error`）
+- [ ] Mutation 关闭覆盖层并调用 `onSuccess` 刷新父组件
+- [ ] API 测试覆盖成功路径、400（校验）和业务错误（404/409）
+- [ ] API 测试使用 `testApi` 并放在 `api/__tests__/` 下
+- [ ] Items 包裹在 `useConstant` 中
+- [ ] 操作列在 `Table` 中内联添加，而不是在共享 items 中
+- [ ] 创建/编辑/详情使用抽屉；删除确认使用模态弹窗
+- [ ] 文件结构遵循 `pages/<feature>/{components/,hooks/,api/}` 约定

--- a/skills/faasjs-best-practices/locales/zh/guidelines/getting-started.md
+++ b/skills/faasjs-best-practices/locales/zh/guidelines/getting-started.md
@@ -8,7 +8,7 @@ FaasJS 是一个受 Rails 启发的精选式全栈 TypeScript 框架，面向数
 
 开始之前，请确保你的环境满足以下要求：
 
-- **Node.js** >= 20.x — FaasJS 依赖现代 Node 特性，包括原生 TypeScript 模块加载。
+- **Node.js** >= 24.x — FaasJS 依赖现代 Node 特性，包括原生 TypeScript 模块加载。
 - **npm** >= 9.x — 用于依赖管理和项目脚手架。
 - **PostgreSQL** >= 14.x — FaasJS 使用 PostgreSQL 作为关系型数据存储（通过 `@faasjs/pg`）。数据库功能和集成测试需要一个运行中的本地实例或 Docker 容器。
 - **基础 TypeScript 知识** — FaasJS 以 TypeScript 为先。你需要熟悉类型、接口和模块导入。
@@ -16,7 +16,7 @@ FaasJS 是一个受 Rails 启发的精选式全栈 TypeScript 框架，面向数
 验证你的环境：
 
 ```bash
-node --version   # >= 20.x
+node --version   # >= 24.x
 npm --version    # >= 9.x
 psql --version   # >= 14.x
 ```

--- a/skills/faasjs-best-practices/locales/zh/guidelines/getting-started.md
+++ b/skills/faasjs-best-practices/locales/zh/guidelines/getting-started.md
@@ -1,0 +1,701 @@
+# 快速开始指南
+
+当你要启动一个新的 FaasJS 项目，或让新开发者加入现有 FaasJS 代码库时，请使用这份指南。它涵盖了完整的搭建流程、第一个功能以及日常开发工作流，让人类和 AI coding agent 都能快速上手。
+
+FaasJS 是一个受 Rails 启发的精选式全栈 TypeScript 框架，面向数据库驱动的 React 业务应用。它提供一条大厨精选式主路径，而不是让每个团队从零拼装自己的框架。
+
+## 前提条件
+
+开始之前，请确保你的环境满足以下要求：
+
+- **Node.js** >= 20.x — FaasJS 依赖现代 Node 特性，包括原生 TypeScript 模块加载。
+- **npm** >= 9.x — 用于依赖管理和项目脚手架。
+- **PostgreSQL** >= 14.x — FaasJS 使用 PostgreSQL 作为关系型数据存储（通过 `@faasjs/pg`）。数据库功能和集成测试需要一个运行中的本地实例或 Docker 容器。
+- **基础 TypeScript 知识** — FaasJS 以 TypeScript 为先。你需要熟悉类型、接口和模块导入。
+
+验证你的环境：
+
+```bash
+node --version   # >= 20.x
+npm --version    # >= 9.x
+psql --version   # >= 14.x
+```
+
+## 创建新项目
+
+最快的方式是使用 `create-faas-app`。
+
+### 第 1 步：搭建项目脚手架
+
+```bash
+npx create-faas-app --name my-app
+```
+
+这条命令会：
+1. 创建 `my-app/` 目录
+2. 安装所有依赖（`npm install`）
+3. 运行初始测试套件验证搭建是否成功
+
+### 第 2 步：选择模板
+
+`create-faas-app` 提供两种模板：
+
+| 模板 | 描述 | 适用场景 |
+|----------|-------------|-------------|
+| `admin`（默认） | 完整管理后台 starter，包含 React、Ant Design 页面、PostgreSQL 集成和一个可直接复用的 users CRUD 切片 | 后台管理系统、内部工具、SaaS dashboard、管理面板 |
+| `minimal` | 更轻量的 starter，包含 React 和最简配置 | 简单 API、BFF 层，或希望从零构建 UI 的场景 |
+
+使用特定模板：
+
+```bash
+npx create-faas-app --name my-app --template minimal
+```
+
+### 第 3 步：进入项目目录
+
+```bash
+cd my-app
+```
+
+项目已准备就绪。如果你选择了 `admin` 模板，初始测试套件在脚手架搭建时已经运行过。你也可以手动运行：
+
+```bash
+npm test
+```
+
+有关可用命令，请参见 [CLI and Tooling 指南](./cli-and-tooling.md)。
+
+## 项目结构概览
+
+搭建完成的 FaasJS 项目遵循一致的布局。以下是你会看到的内容：
+
+```
+my-app/
+  src/
+    faas.yaml              # 运行时配置（服务根路径、plugins、环境覆盖）
+    .faasjs/
+      types.d.ts           # 自动生成的 API 类型声明
+    pages/                 # 前端页面和后端 API 路由
+      index.tsx            # 应用入口页面
+      users/               # 示例功能：users CRUD
+        index.tsx          # 页面入口
+        api/
+          list.api.ts       # POST /pages/users/api/list
+          create.api.ts     # POST /pages/users/api/create
+          detail.api.ts     # POST /pages/users/api/detail
+          update.api.ts     # POST /pages/users/api/update
+          remove.api.ts     # POST /pages/users/api/remove
+          __tests__/        # API 测试
+    types/
+      faasjs-pg.d.ts       # PostgreSQL 表类型声明（声明合并到 `Tables`）
+  migrations/              # 数据库迁移文件（时间戳命名）
+    20250101000000_create_users.ts
+  faas.yaml                #（可选）根级配置覆盖
+  tsconfig.json            # TypeScript 配置
+  vite.config.ts           # Vite + Vitest 配置
+  package.json
+```
+
+### 关键目录
+
+| 目录 | 用途 |
+|-----------|---------|
+| `src/pages/` | 前端页面作为 React 组件，后端 API 路由作为 `.api.ts` 文件。每个功能拥有独立的子目录，包含 `components/`、`hooks/` 和 `api/` 子文件夹。 |
+| `src/types/` | 类型声明文件，包括 `@faasjs/pg` 表类型增强。 |
+| `migrations/` | 时间戳命名的数据库迁移文件。通过 `faasjs-pg` CLI 创建和管理。 |
+
+### 关键配置文件
+
+| 文件 | 用途 | 参考 |
+|------|---------|-----|
+| `src/faas.yaml` | 运行时配置：服务根路径、base path、环境覆盖、plugins | [faas.yaml 规范](../locales/en/specs/faas-yaml.md) |
+| `tsconfig.json` | TypeScript 配置，继承 `@faasjs/types/tsconfig/*` 预设 | [项目配置指南](./project-config.md) |
+| `vite.config.ts` | Vite/Vitest 配置，使用 `@faasjs/dev` 的 `viteConfig` | [项目配置指南](./project-config.md) |
+
+### 零映射路由
+
+API 路由直接映射到 `src/` 下的文件路径。无需路由注册表。
+
+| 文件 | 路由 |
+|------|-------|
+| `src/pages/todo/api/list.api.ts` | `POST /pages/todo/api/list` |
+| `src/pages/todo/api/index.api.ts` | `POST /pages/todo/api` |
+| `src/pages/todo/api/default.api.ts` | `/pages/todo/*` 的 fallback |
+
+完整的路由解析顺序请参见[路由映射规范](../locales/en/specs/routing-mapping.md)。
+
+## 你的第一个功能
+
+本节将带领你完成一个完整的端到端 CRUD 功能：一个包含 PostgreSQL 表、五个 API endpoint、一个 React 前端页面和测试的 Todo 列表。
+
+### 第 1 步：创建迁移
+
+为 `todos` 表创建一个新的迁移文件：
+
+```bash
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg new create_todos
+```
+
+这会创建一个类似 `migrations/20250101000001_create_todos.ts` 的文件。打开它并定义表结构：
+
+```ts
+import type { SchemaBuilder } from '@faasjs/pg'
+
+export function up(builder: SchemaBuilder) {
+  builder.createTable('todos', (table) => {
+    table.number('id').primary()
+    table.string('title')
+    table.text('description').nullable()
+    table.boolean('completed').defaultTo(false)
+    table.timestamps()
+    table.index('title')
+  })
+}
+
+export function down(builder: SchemaBuilder) {
+  builder.dropTable('todos')
+}
+```
+
+运行迁移：
+
+```bash
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg migrate
+```
+
+迁移编写规则请参见 [PG Schema 与迁移指南](./pg-schema-and-migrations.md)。
+
+### 第 2 步：更新表类型声明
+
+在 `src/types/faasjs-pg.d.ts` 中添加 `todos` 表类型：
+
+```ts
+import '@faasjs/pg'
+
+declare module '@faasjs/pg' {
+  interface Tables {
+    todos: {
+      id: number
+      title: string
+      description: string | null
+      completed: boolean
+      created_at: string
+      updated_at: string
+    }
+  }
+}
+```
+
+声明合并规则请参见 [PG 表类型指南](./pg-table-types.md)。
+
+### 第 3 步：创建 API endpoints
+
+在 `src/pages/todos/api/` 下创建五个 API 文件。它们遵循 [CRUD Patterns 指南](./crud-patterns.md)。
+
+#### `src/pages/todos/api/list.api.ts`
+
+```ts
+import { defineApi } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    keyword: z.string().optional(),
+    page: z.coerce.number().int().positive().default(1),
+    pageSize: z.coerce.number().int().positive().default(20),
+  }),
+  async handler({ params }) {
+    // TODO: 使用 params.keyword、params.page、params.pageSize 查询数据库
+    return {
+      rows: [
+        { id: 1, title: 'Learn FaasJS', description: 'Build a Todo app', completed: false, created_at: '2025-01-01T00:00:00Z', updated_at: '2025-01-01T00:00:00Z' },
+      ],
+      total: 1,
+    }
+  },
+})
+```
+
+#### `src/pages/todos/api/create.api.ts`
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    title: z.string().min(1).max(200),
+    description: z.string().optional(),
+  }),
+  async handler({ params }) {
+    // TODO: 插入数据库并返回创建记录
+    return {
+      id: 1,
+      title: params.title,
+      description: params.description || null,
+      completed: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+  },
+})
+```
+
+#### `src/pages/todos/api/detail.api.ts`
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+  }),
+  async handler({ params }) {
+    // TODO: 通过 params.id 从数据库获取
+    const todo = { id: 1, title: 'Learn FaasJS', description: 'Build a Todo app', completed: false, created_at: '2025-01-01T00:00:00Z', updated_at: '2025-01-01T00:00:00Z' }
+
+    if (!todo) {
+      throw new HttpError({ statusCode: 404, message: 'Todo not found' })
+    }
+
+    return todo
+  },
+})
+```
+
+#### `src/pages/todos/api/update.api.ts`
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+    title: z.string().min(1).max(200).optional(),
+    description: z.string().optional(),
+    completed: z.boolean().optional(),
+  }),
+  async handler({ params }) {
+    // TODO: 获取现有 todo，更新并返回
+    return { id: params.id, ...params }
+  },
+})
+```
+
+#### `src/pages/todos/api/remove.api.ts`
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+  }),
+  async handler({ params }) {
+    // TODO: 从数据库删除 where id = params.id
+    return { success: true }
+  },
+})
+```
+
+有关 schema 校验和错误处理规则，请参见 [defineApi 指南](./define-api.md)。
+
+### 第 4 步：创建前端页面
+
+创建一个共享的 items hook，以及包含表格、创建表单和详情视图的页面。
+
+#### `src/pages/todos/hooks/useTodoItems.ts`
+
+```tsx
+import { useConstant } from '@faasjs/react'
+import type { FormItem, TableItem, DescriptionItem } from '@faasjs/ant-design'
+
+export type TodoField = {
+  id: number
+  title: string
+  description: string | null
+  completed: boolean
+  created_at: string
+  updated_at: string
+}
+
+export function useTodoItems() {
+  return useConstant<Array<FormItem & TableItem & DescriptionItem>>(() => [
+    {
+      id: 'title',
+      title: 'Title',
+      required: true,
+      rules: [{ min: 1, max: 200 }],
+    },
+    {
+      id: 'description',
+      title: 'Description',
+      type: 'textarea',
+    },
+    {
+      id: 'completed',
+      title: 'Completed',
+      type: 'switch',
+      tableRender: (value) => (value ? 'Yes' : 'No'),
+    },
+    {
+      id: 'created_at',
+      title: 'Created At',
+      descriptionRender: (value) => new Date(value as string).toLocaleDateString(),
+    },
+  ])
+}
+```
+
+#### `src/pages/todos/index.tsx`
+
+```tsx
+import { Table, Title, useApp, Form, Description, faas } from '@faasjs/ant-design'
+import { Button, Space, Input, Modal } from 'antd'
+import { useState } from 'react'
+
+import { useTodoItems, type TodoField } from './hooks/useTodoItems'
+
+export default function TodosPage() {
+  const { message, notification, setDrawerProps, setModalProps } = useApp()
+  const [keyword, setKeyword] = useState('')
+  const [searchParams, setSearchParams] = useState<{ keyword?: string }>({})
+
+  const items = useTodoItems()
+
+  const handleDelete = (id: number, onSuccess: () => void) => {
+    setModalProps({
+      open: true,
+      title: 'Delete Todo',
+      children: 'Are you sure?',
+      onOk: async () => {
+        try {
+          await faas('/pages/todos/api/remove', { id })
+          message.success('Todo deleted')
+          setModalProps({ open: false })
+          onSuccess()
+        } catch (error: any) {
+          notification.error({ message: 'Delete failed', description: error?.message })
+        }
+      },
+    })
+  }
+
+  return (
+    <Space direction="vertical" style={{ width: '100%' }}>
+      <Title>Todo List</Title>
+
+      <Space>
+        <Input.Search
+          placeholder="Search by title"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          onSearch={() => setSearchParams({ keyword: keyword || undefined })}
+        />
+        <Button type="primary" onClick={() =>
+          setDrawerProps({
+            open: true,
+            title: 'Create Todo',
+            width: 480,
+            children: (
+              <Form
+                items={items}
+                faas={{
+                  action: '/pages/todos/api/create',
+                  onSuccess: () => {
+                    message.success('Todo created')
+                    setDrawerProps({ open: false })
+                    reload()
+                  },
+                  onError: (error) =>
+                    notification.error({ message: 'Create failed', description: error?.message }),
+                }}
+              />
+            ),
+          })
+        }>
+          Create Todo
+        </Button>
+      </Space>
+
+      <Table<TodoField>
+        rowKey="id"
+        items={[
+          ...items,
+          {
+            id: 'actions',
+            title: 'Actions',
+            tableRender: (_, row) => (
+              <Space>
+                <Button type="link" onClick={() =>
+                  setDrawerProps({
+                    open: true,
+                    title: 'Todo Detail',
+                    width: 480,
+                    children: <Description<TodoField> items={items} faasData={{ action: '/pages/todos/api/detail', params: { id: row.id } }} />,
+                  })
+                }>
+                  Detail
+                </Button>
+                <Button type="link" onClick={() =>
+                  setDrawerProps({
+                    open: true,
+                    title: 'Edit Todo',
+                    width: 480,
+                    children: (
+                      <Form
+                        initialValues={row}
+                        items={items}
+                        faas={{
+                          action: '/pages/todos/api/update',
+                          params: (values) => ({ ...values, id: row.id }),
+                          onSuccess: () => {
+                            message.success('Todo updated')
+                            setDrawerProps({ open: false })
+                            reload()
+                          },
+                          onError: (error) =>
+                            notification.error({ message: 'Update failed', description: error?.message }),
+                        }}
+                      />
+                    ),
+                  })
+                }>
+                  Edit
+                </Button>
+                <Button type="link" danger onClick={() => handleDelete(row.id, reload)}>
+                  Delete
+                </Button>
+              </Space>
+            ),
+          },
+        ]}
+        faasData={{
+          action: '/pages/todos/api/list',
+          params: searchParams,
+        }}
+      />
+    </Space>
+  )
+}
+```
+
+> 上面的 `reload()` 是表格的 reload 函数。在实际组件中，你需要通过 `Table.faasData` 的 render-prop 或 ref 模式获取它。完整的模式请参见 [CRUD Patterns 指南](./crud-patterns.md) 和 [Ant Design 指南](./ant-design.md)。
+
+页面布局和组件模式请参见 [Ant Design 指南](./ant-design.md)，`useFaas`、`faas` 及生命周期选项请参见 [React 数据请求指南](./react-data-fetching.md)。
+
+### 第 5 步：添加测试
+
+在 `src/pages/todos/api/__tests__/` 下创建 API 测试。每个测试使用 `@faasjs/dev` 的 `testApi`。
+
+```ts
+// src/pages/todos/api/__tests__/create.test.ts
+import { testApi } from '@faasjs/dev'
+import { describe, expect, it } from 'vitest'
+
+import createApi from '../create.api'
+
+describe('todos/api/create', () => {
+  const handler = testApi(createApi)
+
+  it('使用有效参数创建 todo', async () => {
+    const response = await handler({
+      title: 'Learn FaasJS',
+      description: 'Build a Todo app',
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.data?.title).toBe('Learn FaasJS')
+  })
+
+  it('title 为空时返回 400', async () => {
+    const response = await handler({ title: '' })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.error?.message).toContain('Invalid params')
+  })
+})
+```
+
+```ts
+// src/pages/todos/api/__tests__/list.test.ts
+import { testApi } from '@faasjs/dev'
+import { describe, expect, it } from 'vitest'
+
+import listApi from '../list.api'
+
+describe('todos/api/list', () => {
+  const handler = testApi(listApi)
+
+  it('返回分页结果', async () => {
+    const response = await handler({ page: 1, pageSize: 20 })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.data?.rows).toBeDefined()
+    expect(response.data?.total).toBeDefined()
+  })
+})
+```
+
+测试原则请参见[测试指南](./testing.md)，完整的 API 测试覆盖示例请参见 [CRUD Patterns 指南](./crud-patterns.md)。
+
+### 第 6 步：运行类型生成和测试
+
+创建 API 文件后，生成类型声明以使前端获得完整的类型推导：
+
+```bash
+npx faas types
+```
+
+这会更新 `src/.faasjs/types.d.ts`，为所有 `.api.ts` 文件添加类型化的路由。
+
+运行测试以验证一切正常：
+
+```bash
+vp test
+```
+
+`admin` 模板还包含一个 users 切片，使用相同的模式。你可以将其复制作为自己功能的参考。推荐的功能切片布局请参见[应用切片指南](./application-slices.md)。
+
+## 核心概念
+
+### `defineApi` 与 endpoint 定义
+
+每个 API endpoint 都是一个默认导出 `defineApi(...)` 的文件。`schema` 字段使用 Zod 进行输入校验，`handler` 接收类型化的 `params`。
+
+```ts
+import { defineApi, HttpError } from '@faasjs/core'
+import * as z from 'zod'
+
+export default defineApi({
+  schema: z.object({
+    id: z.coerce.number().int().positive(),
+  }),
+  async handler({ params }) {
+    // params.id 类型为 number
+    return { id: params.id }
+  },
+})
+```
+
+详细规则请参见 [defineApi 指南](./define-api.md)。
+
+### 零映射路由
+
+API 文件路径直接映射到请求路径 — 无需路由配置。`src/pages/todos/api/list.api.ts` 文件响应 `POST /pages/todos/api/list` 请求。完整的解析顺序请参见[路由映射规范](../locales/en/specs/routing-mapping.md)。
+
+### `faas.yaml` 配置层级
+
+配置按文件位置和运行环境分层。`src/faas.yaml` 设置基线，更深的 `faas.yaml` 文件可以覆盖特定路径范围的设置。运行环境键（`development`、`production` 等）允许按环境覆盖。
+
+```yaml
+defaults:
+  server:
+    root: .
+    base: /api
+  plugins:
+    http:
+      type: http
+      config:
+        cookie:
+          secure: false
+```
+
+完整规范请参见 [faas.yaml 规范](../locales/en/specs/faas-yaml.md)。
+
+### `@faasjs/ant-design` 组件
+
+`@faasjs/ant-design` 包提供了业务 UI 包装器，处理 loading、error 和数据请求状态：
+
+| 组件 | 用途 |
+|-----------|---------|
+| `Table.faasData` | 服务端驱动的列表，参数变化时自动重新请求 |
+| `Form.faas` | 表单提交，内置 loading、校验和反馈 |
+| `Description.faasData` | 详情视图，含 loading 和 error 状态 |
+| `useApp()` | 访问 `message`、`notification`、`setDrawerProps`、`setModalProps` |
+
+组件模式请参见 [Ant Design 指南](./ant-design.md)。
+
+### `useFaas` / `faas` 数据请求
+
+| API | 使用场景 |
+|-----|-------------|
+| `useFaas(action, params, options)` | 组件拥有的请求状态，含 loading、error、debounce、polling 和 reload |
+| `faas(action, params)` | 命令式一次性请求（表单提交、删除） |
+| `Form.faas` | 表单提交（优先于原始 `faas`） |
+
+生命周期控制和模式请参见 [React 数据请求指南](./react-data-fetching.md)。
+
+### 插件机制
+
+Plugins 将横切关注点（auth、租户上下文、请求元数据）注入请求生命周期。它们在 `faas.yaml` 的 `plugins` 键下配置，并可以用类型化字段扩展 `defineApi` 的 handler 上下文。
+
+插件编写请参见 [Plugin 规范](../locales/en/specs/plugin.md)。
+
+## 开发工作流
+
+FaasJS 工具链使用 `vp`（Vite Plus）作为开发任务的主要入口。
+
+| 命令 | 用途 |
+|---------|---------|
+| `vp dev` | 启动开发服务器，支持热重载 |
+| `vp test` | 使用 Vitest 运行所有测试 |
+| `vp test <pattern>` | 运行匹配文件名的测试 |
+| `vp check --fix` | 运行 lint 检查和格式化（oxlint + oxfmt） |
+| `npx faas types` | 重新生成 `src/.faasjs/types.d.ts` 中的 API 类型声明 |
+| `npx faasjs-pg migrate` | 运行待执行的数据库迁移 |
+| `npx faasjs-pg new <name>` | 创建新的时间戳命名迁移文件 |
+
+### 日常迭代循环
+
+1. 启动开发服务器：`vp dev`
+2. 编辑 API 文件（`*.api.ts`）和前端页面（`*.tsx`）
+3. 创建、重命名或移动 `.api.ts` 文件后，重新生成类型：`npx faas types`
+4. 运行聚焦测试：`vp test src/pages/todos/api/__tests__/list.test.ts`
+5. 提交前：`vp check --fix && vp test`
+
+### 数据库迁移
+
+```bash
+# 创建新迁移
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg new add_due_date_to_todos
+
+# 检查迁移状态
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg status
+
+# 应用待执行迁移
+DATABASE_URL=postgres://localhost:5432/myapp npx faasjs-pg migrate
+```
+
+所有命令和故障排查请参见 [CLI and Tooling 指南](./cli-and-tooling.md)。
+
+## 下一步
+
+现在你已拥有一个可运行的项目，可以探索以下详细指南：
+
+| 指南 | 涵盖内容 |
+|-------|----------------|
+| [应用切片指南](./application-slices.md) | 垂直功能结构和推荐布局 |
+| [CRUD Patterns 指南](./crud-patterns.md) | 从 API 到 React 页面的完整 CRUD 实现 |
+| [defineApi 指南](./define-api.md) | API endpoint schema、校验和错误处理 |
+| [Ant Design 指南](./ant-design.md) | 页面结构、路由、CRUD 组合和 UI 反馈 |
+| [React 数据请求指南](./react-data-fetching.md) | `useFaas`、`faas`、生命周期控制、轮询和重试 |
+| [PG Schema 与迁移指南](./pg-schema-and-migrations.md) | 数据库迁移编写规则 |
+| [PG 表类型指南](./pg-table-types.md) | 在 `Tables` 上的声明合并，实现类型安全的查询 |
+| [PG 查询构建器与原生 SQL 指南](./pg-query-builder.md) | 使用 `@faasjs/pg` 构建查询 |
+| [测试指南](./testing.md) | 测试原则和实践 |
+| [React 测试指南](./react-testing.md) | React 组件和请求流测试 |
+| [PG 测试指南](./pg-testing.md) | PostgreSQL 集成测试 |
+| [CLI and Tooling 指南](./cli-and-tooling.md) | 所有 CLI 命令、环境变量和故障排查 |
+| [项目配置指南](./project-config.md) | TypeScript、Vite 和工具链配置 |
+| [文件约定](./file-conventions.md) | 文件放置和命名约定 |
+| [Jobs 指南](./jobs.md) | 使用 `@faasjs/jobs` 的后台任务 |
+| [Logger 指南](./logger.md) | 日志模式和日志级别 |
+| [代码注释指南](./code-comments.md) | JSDoc 和注释约定 |
+| [faas.yaml 规范](../locales/en/specs/faas-yaml.md) | faas.yaml 配置完整参考 |
+| [路由映射规范](../locales/en/specs/routing-mapping.md) | 零映射路由解析 |
+| [Plugin 规范](../locales/en/specs/plugin.md) | 插件编写和配置 |
+| [Http 协议规范](../locales/en/specs/http-protocol.md) | HTTP 请求/响应协议细节 |


### PR DESCRIPTION
## Summary

Added three new guides to the `faasjs-best-practices` skill to improve AI coding agent efficiency and new developer onboarding.

### New Guides

#### 1. Getting Started Guide (`guidelines/getting-started.md`)
- Full onboarding for new developers and new projects
- Prerequisites, project creation (`npm create @faasjs/app`), structure tour
- End-to-end Todo CRUD first feature walkthrough (migration → types → 5 APIs → React page → tests → typegen)
- Key concepts reference (defineApi, Zero-Mapping, faas.yaml, @faasjs/ant-design, useFaas, plugins)
- Daily development workflow (vp dev, vp test, vp check --fix, faas types, migrations)
- Links to all 18 guidelines and 4 specs

#### 2. CRUD Patterns Guide (`guidelines/crud-patterns.md`)
- Quick-reference tables for API endpoint mapping and file naming
- Shared `items` metadata pattern across Form/Table/Description
- List page, detail, create form, update form, and delete patterns with complete code
- Complete CRUD slice layout reference
- Testing CRUD endpoints with `testApi`
- Agent efficiency tips for faster page generation (target: 2-3x speedup)

#### 3. CLI and Tooling Guide (`guidelines/cli-and-tooling.md`)
- `faas CLI` reference (run, types, global options)
- Vite Plus / `vp` commands (check --fix, test, dev)
- Project creation with `create-faas-app`
- Migration commands (`faasjs-pg migrate up/down/status/new`)
- Type generation workflow
- Common command errors and recovery steps
- Environment variables (DATABASE_URL, FaasEnv, FaasLog)

### Chinese Translations
All three guides include full Chinese translations under `locales/zh/guidelines/`.

### SKILL.md Updates
- Added **3 new Agent Task Routing** entries for the new guides
- Added **3 new Guidelines list** entries with descriptions
