### PR TITLE
refactor: 精简 vite.config.ts，使用 @faasjs/dev 和 @faasjs/pg-dev 的导出

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,8 @@ import { join } from 'node:path'
 import react from '@vitejs/plugin-react'
 import { defineConfig, type UserConfig } from 'vite-plus'
 import type { PackUserConfig } from 'vite-plus/pack'
-
-import { oxfmtConfig } from './packages/dev/src/vite/oxfmt.ts'
-import { oxlintConfig } from './packages/dev/src/vite/oxlint.ts'
-import { PgVitestPlugin } from './packages/pg-dev/src/plugin/index.ts'
+import { viteConfig } from '@faasjs/dev'
+import { PgVitestPlugin } from '@faasjs/pg-dev'
 
 const tests = ['packages/**/*.test.ts']
 
@@ -106,14 +104,10 @@ const pack: PackUserConfig[] = [
 
 export default defineConfig({
   plugins: react(),
-  staged: {
-    '*': 'vp check --fix',
-  },
-  resolve: {
-    tsconfigPaths: true,
-  },
-  fmt: oxfmtConfig,
-  lint: oxlintConfig,
+  staged: viteConfig.staged,
+  resolve: viteConfig.resolve,
+  fmt: viteConfig.fmt,
+  lint: viteConfig.lint,
   pack,
   test: {
     restoreMocks: true,


### PR DESCRIPTION
## 变更说明

精简 `vite.config.ts`，充分利用 `@faasjs/dev` 和 `@faasjs/pg-dev` 已提供的功能。

### 具体改动

1. **导入路径规范化**
   - `oxfmtConfig` / `oxlintConfig` 从相对路径导入 → 统一为 `viteConfig` 从 `@faasjs/dev` 导入
   - `PgVitestPlugin` 从相对路径导入 → 从 `@faasjs/pg-dev` 导入

2. **配置字段精简化**
   - `staged` / `resolve` / `fmt` / `lint` 从内联对象 → 引用 `viteConfig.*` 对应字段
   - 值完全等价，行为不变

3. **保留不变的**
   - `plugins: react()` — 手动管理，避免引入 `viteFaasJsServer()`（不适合 monorepo 根目录）
   - `pack` / `test` — monorepo 特有逻辑，无法抽象

### 统计

- 6 行新增，12 行删除，净减 6 行
- 配置语义零变化
