### PR TITLE
docs: 更新 CHANGELOG.md，新增 v8.0.0-beta.28 条目

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 FaasJS use [Semantic Versioning](https://semver.org/).
 
+[`v8.0.0-beta.28 (2026-05-07)`](https://github.com/faasjs/faasjs/compare/v8.0.0-beta.27...HEAD)
+
+- `faasjs`
+  - [Feature] Add English translations of specs (http-protocol, plugin, routing-mapping) and update routing-mapping link in file-conventions.
+  - [Feature] Add Getting Started, CRUD Patterns, and CLI and Tooling guides to faasjs-best-practices skill.
+  - [Fix] Update Node.js requirement from >=20.x to >=24.x in getting-started guide.
+  - [Fix] Remove standalone type aliases guideline and references from faasjs-best-practices skill.
+  - [Fix] Remove cli package from buildApiDocs package.json filter.
+  - [Fix] Fix lint warnings (65 warnings down to 0).
+
+- `@faasjs/core`
+  - [Break] Remove Auth plugin exports from the core index; reorganize Auth plugin into a standalone define-api directory.
+  - [Fix] Replace `any` with `unknown` in core types for better type safety.
+
+- `@faasjs/types`
+  - [Break] Make `FaasParams` and `FaasData` strictly derived from `FaasActions`; remove support for free-form params/data.
+  - [Fix] Replace `any` with `unknown` in type definitions.
+
+- `@faasjs/react`
+  - [Fix] Adapt `FaasDataWrapper` and related hooks to strict `FaasParams`/`FaasData` types.
+  - [Fix] Replace `any` with `unknown` in React component types.
+
+- `@faasjs/dev`
+  - [Fix] Adapt `ApiTester` and test helpers to strict `FaasParams`/`FaasData` types.
+  - [Fix] Replace `any` with `unknown` in dev utility types.
+
+- `@faasjs/logger`
+  - [Break] Change default log level from `debug` to `info`; suppress verbose lifecycle, SQL timing, and Cookie/Session logs by default.
+  - [Fix] Unify frontend log format and demote Transport lifecycle logs from `info` to `debug`.
+
+- `@faasjs/pg`
+  - [Break] Remove the `testing-support` subpath export; testing utilities are now exclusively in `@faasjs/pg-dev`.
+
+- `@faasjs/pg-dev`
+  - [Break] Remove global setup file; `testing-setup.ts` now starts PGlite directly.
+  - [Break] Remove `PG_VITEST_DATABASE_URL_ENV_NAME` constant; use the literal `'DATABASE_URL'` instead.
+  - [Break] Remove `requireTestingDatabaseUrl` helper; tests read `process.env.DATABASE_URL` directly.
+
+- `create-faas-app`
+  - [Fix] Fix `FaasActions` type declaration in scaffolded templates.
+
 [`v8.0.0-beta.27 (2026-04-24)`](https://github.com/faasjs/faasjs/compare/v8.0.0-beta.26...v8.0.0-beta.27)
 
 - `faasjs`


### PR DESCRIPTION
## 变更说明

将 v8.0.0-beta.27（2026-04-24）至当前 HEAD 之间的近期变更同步到 CHANGELOG.md，新增 **v8.0.0-beta.28 (2026-05-07)** 条目。

### 涉及 PR
- #2370 feat/en-specs-translation
- #2371 feat/faasjs-best-practices-new-guides
- #2372 refactor/any-to-unknown
- #2373 refactor/pg-testing-to-pg-dev
- #2376 feat/strict-faas-params-data
- #2377 fix/lint-warnings

### 主要变更
- **@faasjs/types**: FaasParams/FaasData 改为严格基于 FaasActions
- **@faasjs/core**: Auth plugin 移入独立文件；any → unknown 类型改进
- **@faasjs/logger**: 默认日志级别从 debug 改为 info
- **@faasjs/pg/pg-dev**: testing-support 迁移至 pg-dev；移除 global setup 等
- **faasjs**: 新增英文 specs 文档和最佳实践指南
