### PR TITLE
docs: add unreleased CHANGELOG entries for v8.0.0-beta.27..HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 FaasJS use [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+- `faasjs`
+  - [Feature] Add Getting Started, CRUD Patterns, and CLI and Tooling guides to faasjs-best-practices.
+  - [Feature] Add English specs for faas-yaml, http-protocol, plugin, and routing-mapping.
+  - [Fix] Improve guide documentation readability and consistency across multiple files.
+  - [Fix] Remove stale spec page references from docgen and clean up references directory.
+  - [Fix] Update Node.js minimum version requirement from >=20.x to >=24.x in getting-started guide.
+
+- `@faasjs/types`
+  - [Break] `FaasParams<T>` and `FaasData<T>` now return `never` for object-type arguments, enforcing strict typing via `FaasActions`. String literals not registered in `FaasActions` fall back to `Record<string, unknown>`.
+  - [Feature] Replace `any` with `unknown` in `FaasAction`, `FaasActionUnionType`, `InferFaasAction`, `InferFaasApi`, and related type definitions for improved type safety.
+
+- `@faasjs/core`
+  - [Feature] Replace `any` with `unknown` in `DefineApiData` default type parameters (`TEvent`, `TContext`, `TResult`) and related internals for improved type safety.
+
+- `@faasjs/node-utils`
+  - [Feature] Change default Logger level from `debug` to `info`, reducing default log noise from plugin lifecycle, SQL timing, Cookie/Session logs.
+  - [Fix] Lower Transport lifecycle logs (`register`/`unregister`/`stopping`) from `info` to `debug`.
+
+- `@faasjs/react`
+  - [Fix] Remove unnecessary `console.debug` for mock requests. Add `[FaasJS]` prefix to `console.warn` messages.
+
+- `@faasjs/ant-design`
+  - [Fix] Remove unnecessary `console.debug('location', location)` from App component.
+
+- `@faasjs/pg`
+  - [Break] Remove `testing-support` module (`requireTestingDatabaseUrl`, `PG_VITEST_DATABASE_URL_ENV_NAME`, `global-setup.ts`, `setup.ts`). Testing setup utilities are now in `@faasjs/pg-dev`.
+
+- `@faasjs/pg-dev`
+  - [Feature] Move testing setup from `@faasjs/pg/testing-support` into `@faasjs/pg-dev`. Use `testing-setup.ts` directly instead of `global-setup.ts` + `setup.ts`.
+
+- `@faasjs/create-faas-app`
+  - [Fix] Add `declare module '@faasjs/types'` block to scaffolded admin template for strict `FaasActions` type compatibility.
+
 [`v8.0.0-beta.27 (2026-04-24)`](https://github.com/faasjs/faasjs/compare/v8.0.0-beta.26...v8.0.0-beta.27)
 
 - `faasjs`


### PR DESCRIPTION
## 变更说明

根据 [contributing/documentation-sync.md](https://github.com/faasjs/faasjs/blob/main/contributing/documentation-sync.md) 的要求，在 `CHANGELOG.md` 顶部添加 `[Unreleased]` 条目，汇总自 v8.0.0-beta.27 以来对终端用户有意义的变更。

### 涵盖的变更

- **`faasjs`**: 新增 Getting Started / CRUD Patterns / CLI and Tooling 指南；新增英文规范文档（faas-yaml、http-protocol、plugin、routing-mapping）；文档清理；Node.js 最低版本更新至 >=24.x
- **`@faasjs/types`**: `FaasParams<T>`/`FaasData<T>` 对对象类型返回 `never`（Breaking）；`any`→`unknown` 类型安全改进
- **`@faasjs/core`**: `DefineApiData` 默认类型参数从 `any` 改为 `unknown`
- **`@faasjs/node-utils`**: Logger 默认级别从 `debug` 改为 `info`；Transport 生命周期日志降级
- **`@faasjs/react`**: 移除冗余 `console.debug`，统一 `[FaasJS]` 前缀
- **`@faasjs/ant-design`**: 移除 App 组件中冗余 debug 日志
- **`@faasjs/pg`**: 移除 `testing-support` 模块（Breaking）
- **`@faasjs/pg-dev`**: 测试设置迁入 `@faasjs/pg-dev`
- **`@faasjs/create-faas-app`**: admin 模板增加 `FaasActions` 类型声明

### 依据

参照 documentation-sync.md 第 4 步 "Update release notes when needed" 及第 69 行规则：
- 使用 `git log v8.0.0-beta.27..HEAD` 审查完整变更范围
- 只包含对终端用户有意义的条目，跳过纯内部重构/测试
