### PR TITLE
chore: add avoid unnecessary intermediate variables rule to Global Rules

### DIFF
--- a/skills/faasjs-best-practices/SKILL.md
+++ b/skills/faasjs-best-practices/SKILL.md
@@ -29,6 +29,7 @@ Before changing code, inspect nearby examples and read only the guides needed fo
 - Do not invent a new alias in code unless the corresponding `tsconfig.json` and runtime resolver are configured in the same change.
 - Keep changes minimal and task-scoped: no extra features, drive-by refactors, opportunistic cleanup, feature flags, transition shims, or speculative future-proofing.
 - Keep code direct: validate at system boundaries such as user input and external APIs, fail fast on invalid internal data, and do not add silent fallbacks or impossible-case handling.
+- Avoid unnecessary intermediate variables: return or pass values directly instead of assigning to a single-use variable. An intermediate variable is justified when it documents a non-trivial condition, is referenced more than once, or breaks a long chain for readability.
 - Do not create standalone type aliases or interfaces when TypeScript can infer the type from the expression, schema, or return statement; rely on inference first and add explicit types only at API boundaries, shared contracts, or where inference is ambiguous.
 - Extract helpers, hooks, components, or abstractions only when they are reused, create a real boundary, or simplify a large block; keep one-off code inline unless the body is over about 20 lines.
 - Document package public exports with JSDoc. Add JSDoc for shared app exports when the caller contract is not obvious. Do not add comments, docstrings, or type annotations to untouched code.


### PR DESCRIPTION
## 变更说明

在 Global Rules 中新增一条规则，要求在代码中避免不必要的中间变量，以**减少代码量**并**提升代码直观性**。

### 新增规则

```
- Avoid unnecessary intermediate variables: return or pass values directly instead of assigning to a single-use variable. An intermediate variable is justified when it documents a non-trivial condition, is referenced more than once, or breaks a long chain for readability.
```

### 插入位置

位于 Line 31 "Keep code direct"（控制流直接性）与 Line 33 "Do not create standalone type aliases"（类型直接性）之间，形成完整的直接性递进链：

| 行号 | 主题 | 层面 |
|------|------|------|
| 31 | Keep code direct | 控制流 |
| **32 (新)** | **Avoid unnecessary intermediate variables** | **运行时变量** |
| 33 | Do not create standalone type aliases | 类型声明 |
| 34 | Extract only when reused | 抽象/函数 |

### 覆盖场景

**不推荐（多余变量）→ 推荐（直接）**
- `const r = fn(); return r;` → `return fn();`
- `const n = user.name; return \`Hello ${n}\`;` → `return \`Hello ${user.name}\`;`
- `const items = list.map(fn); return items;` → `return list.map(fn);`

**允许的合理变量**
- 引用多次（如 `isValid` 在条件中多处使用）
- 用于文档化非显而易见的状态或计算
- 打断过长表达式链以提升可读性
