### PR TITLE
feat: useFaas 轮询在离线时暂停，恢复网络后自动继续

### DIFF
--- a/packages/react/src/useFaasRequest.ts
+++ b/packages/react/src/useFaasRequest.ts
@@ -114,6 +114,7 @@ export function useFaasRequest<Path extends FaasActionPaths>({
   const handledRequestTriggerTimesRef = useRef(-1)
   const pollingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const hasLoadedRef = useRef(false)
+  const isOnlineRef = useRef(typeof navigator !== 'undefined' ? navigator.onLine : true)
   const beforeSendRef = useRef(beforeSend)
   const onSuccessRef = useRef(onSuccess)
   const sendRef = useRef(send)
@@ -165,12 +166,36 @@ export function useFaasRequest<Path extends FaasActionPaths>({
       clearPollingTimer()
 
       if (!options.polling || options.polling <= 0 || !isCurrentRequest()) return
+      if (!isOnlineRef.current) return
 
       pollingTimerRef.current = setTimeout(() => {
         if (!isCurrentRequest()) return
+        if (!isOnlineRef.current) return
 
         setRequestTrigger((prev) => ({ times: prev.times + 1, silent: true }))
       }, options.polling)
+    }
+
+    const handleOnline = () => {
+      isOnlineRef.current = true
+      if (options.polling && options.polling > 0 && !skip)
+        setRequestTrigger((prev) => ({
+          times: prev.times + 1,
+          silent: hasLoadedRef.current,
+        }))
+    }
+
+    const handleOffline = () => {
+      isOnlineRef.current = false
+      if (pollingTimerRef.current) {
+        clearTimeout(pollingTimerRef.current)
+        pollingTimerRef.current = null
+      }
+    }
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('online', handleOnline)
+      window.addEventListener('offline', handleOffline)
     }
 
     const rejectPending = (reason: any) => {
@@ -259,6 +284,10 @@ export function useFaasRequest<Path extends FaasActionPaths>({
       return () => {
         clearTimeout(timeout)
         clearPollingTimer()
+        if (typeof window !== 'undefined') {
+          window.removeEventListener('online', handleOnline)
+          window.removeEventListener('offline', handleOffline)
+        }
         if (controllerRef.current === controller) controllerRef.current = null
         controller.abort()
         setLoading(false)
@@ -270,6 +299,10 @@ export function useFaasRequest<Path extends FaasActionPaths>({
 
     return () => {
       clearPollingTimer()
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('online', handleOnline)
+        window.removeEventListener('offline', handleOffline)
+      }
       if (controllerRef.current === controller) controllerRef.current = null
       controller.abort()
       setLoading(false)


### PR DESCRIPTION
## 变更

为 `useFaas` / `useFaasStream` 的轮询（polling）功能增加离线感知能力：
- **离线时暂停轮询**：检测到 `navigator.onLine` 为 `false` 时，停止调度新的轮询请求，避免产生无意义的网络错误
- **恢复网络后自动继续**：监听 `online` 事件，自动触发 silent reload 恢复数据并重启轮询

## 实现

- 仅修改 `packages/react/src/useFaasRequest.ts`（`useFaas` 和 `useFaasStream` 共用此模块）
- 新增 `isOnlineRef` 跟踪当前在线状态
- 在 `schedulePolling` 中检查在线状态，离线时跳过轮询调度
- 监听 `window` 的 `online`/`offline` 事件，在 effect cleanup 中正确移除

## 行为对比

| 场景 | 之前 | 之后 |
|------|------|------|
| 轮询中网络断开 | 持续失败重试，产生大量错误 | 暂停轮询，等待网络恢复 |
| 网络恢复 | 需手动 reload | 自动 silent reload，恢复轮询 |
| 无轮询的请求 | 无变化 | 无变化 |
