### PR TITLE
chore: 将技能文档外部链接改为技能文件夹内子文档

### DIFF
--- a/skills/faasjs-best-practices/guidelines/cli-and-tooling.md
+++ b/skills/faasjs-best-practices/guidelines/cli-and-tooling.md
@@ -174,7 +174,7 @@ See [Testing Guide](./testing.md) for testing principles and [Project Config Gui
 - **Check**: Does `src/faas.yaml` exist? Is the YAML valid?
 - **Check**: Does `src/` contain at least one `.api.ts` file?
 - **Recovery**: Run `npx faas types --root .` if outside the project root.
-- **See**: [faas.yaml Specification](../../../docs/specs/faas-yaml.md)
+- **See**: [faas.yaml Specification](./faas-yaml.md)
 
 ### `faasjs-pg` commands fail
 
@@ -245,7 +245,7 @@ npx faas types --root /path/to/project
 ## Review Checklist
 
 - `.api.ts` changes are followed by `faas types` (or a recorded reason)
-- `faas.yaml` is valid YAML and follows the [faas.yaml specification](../../../docs/specs/faas-yaml.md)
+- `faas.yaml` is valid YAML and follows the [faas.yaml specification](./faas-yaml.md)
 - `vp check --fix` passes before commit
 - `vp test` passes (or a recorded blocker + narrower validation that did run)
 - `DATABASE_URL` is set before running `faasjs-pg` migration commands

--- a/skills/faasjs-best-practices/guidelines/faas-yaml.md
+++ b/skills/faasjs-best-practices/guidelines/faas-yaml.md
@@ -1,0 +1,102 @@
+# faas.yaml Configuration Specification
+
+## Background
+
+`faas.yaml` is the runtime configuration entry used by FaasJS config loading, local dev server resolution, and type generation.
+
+This spec defines the current public baseline that matches FaasJS runtime behavior.
+
+Related references:
+
+- `packages/node-utils/src/load_config.ts`
+- `packages/node-utils/src/parse_yaml/index.ts`
+- `packages/dev/src/server_config.ts`
+- `packages/dev/src/typegen.ts`
+- `@faasjs/node-utils` `parseYaml()`
+
+## Goals
+
+- Keep config discovery and merge order deterministic.
+- Keep staging-level validation predictable.
+- Define the supported YAML subset explicitly.
+- Give custom Node.js tooling a supported parser entrypoint for the same YAML subset.
+
+## Normative Rules
+
+### 1. File naming and placement
+
+1. Configuration file name MUST be `faas.yaml`.
+2. Project-level configuration SHOULD be placed at `<projectRoot>/src/faas.yaml`.
+3. Additional `faas.yaml` files MAY be placed in nested directories under `src/` for local overrides.
+
+### 2. Discovery and merge order
+
+1. For an API file under `<srcRoot>/<path>/<file>.api.ts`, the loader MUST discover files from shallow to deep:
+   - `<srcRoot>/faas.yaml`
+   - `<srcRoot>/<path-segment-1>/faas.yaml`
+   - ...
+   - `<srcRoot>/<path>/faas.yaml`
+2. Effective config MUST be merged in discovered order where deeper config overrides shallower config.
+3. For each staging key `S != defaults`, effective staging config MUST be `deepMerge(defaults, S)` after file-level merge is done.
+4. If requested staging does not exist, runtime MUST fall back to `defaults`, then to an empty object.
+
+### 3. Root object and staging keys
+
+1. The parsed root value MUST be an object when provided.
+2. Each top-level staging value MUST be an object when provided.
+3. `defaults` SHOULD exist and SHOULD contain shared baseline settings.
+
+### 4. `server` node contract
+
+1. `<staging>.server`, when present, MUST be an object.
+2. `<staging>.server.root`, when present, MUST be a string.
+3. `<staging>.server.base`, when present, MUST be a string.
+4. In `@faasjs/dev`, `server.root` MUST be resolved relative to project root and represent project root.
+5. In `@faasjs/dev`, source root MUST be `<server.root>/src`.
+6. In type generation, output path MUST be `<server.root>/src/.faasjs/types.d.ts`.
+
+### 5. `plugins` node authoring
+
+1. `<staging>.plugins` MAY be omitted.
+2. Recommended authoring shape is a mapping from plugin key to plugin config object.
+3. Plugin key SHOULD be stable within the same staging because `loadConfig()` derives runtime `name` from that key.
+4. `name` is a loader-generated runtime field and SHOULD NOT be authored manually in `faas.yaml`.
+5. A plugin config object MAY contain `type`, `config`, and other plugin-specific fields.
+6. Plugin `type` MAY be authored as a built-in plugin type, bare package type, scoped package name, relative path, absolute path, or `file://` local file URL.
+7. Plugin-specific inner fields are outside the scope of this spec and are preserved during merge.
+
+### 6. Supported YAML subset
+
+1. The parser MUST support indentation-based mappings and sequences.
+2. The parser MUST support plain, single-quoted, and double-quoted scalars.
+3. The parser MUST support scalar values: `null`, `boolean`, `number`, and `string`.
+4. The parser MUST support anchors (`&`), aliases (`*`), and merge key (`<<`) for mappings.
+5. The parser MUST NOT allow tabs for indentation.
+6. The parser MUST NOT allow multiple YAML documents (`---`, `...`).
+7. The parser MUST NOT allow block scalars (`|`, `>`), YAML tags (`!`), or non-empty flow collections (`[a]`, `{a: 1}`).
+8. Empty flow collections `[]` and `{}` MAY be used.
+
+### 7. Error handling
+
+1. Invalid config structure MUST throw an error prefixed with:
+   - `[loadConfig] Invalid faas.yaml <filePath> at "<keyPath>": <reason>`
+2. Unsupported YAML syntax/features MUST throw parse errors prefixed with:
+   - `[parseYaml]`
+3. Config consumers (for example dev server startup or typegen) SHOULD fail fast when config loading fails.
+
+## Examples
+
+```yaml
+defaults:
+  server:
+    root: .
+    base: /api
+  plugins:
+    http:
+      type: http
+      config:
+        cookie:
+          secure: false
+          session:
+            secret: replace-me
+```

--- a/skills/faasjs-best-practices/guidelines/file-conventions.md
+++ b/skills/faasjs-best-practices/guidelines/file-conventions.md
@@ -118,7 +118,7 @@ Frontend page organization under `src/pages` is a project convention, not an imp
 
 ### 4. Follow routing-mapping for backend files
 
-- Backend route files MUST follow the [routing-mapping specification](../../../docs/specs/routing-mapping.md).
+- Backend route files MUST follow the [routing-mapping specification](./routing-mapping.md).
 - API entry files MUST end with `.api.ts`.
 - API files SHOULD be placed under the page or feature's `api/` directory.
 - Route paths and file paths MUST keep direct Zero-Mapping alignment.

--- a/skills/faasjs-best-practices/guidelines/getting-started.md
+++ b/skills/faasjs-best-practices/guidelines/getting-started.md
@@ -110,7 +110,7 @@ my-app/
 
 | File             | Purpose                                                                   | See                                                         |
 | ---------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| `src/faas.yaml`  | Runtime configuration: server root, base path, staging overrides, plugins | [faas.yaml Specification](../../../docs/specs/faas-yaml.md) |
+| `src/faas.yaml`  | Runtime configuration: server root, base path, staging overrides, plugins | [faas.yaml Specification](./faas-yaml.md) |
 | `tsconfig.json`  | TypeScript config, extends `@faasjs/types/tsconfig/*` presets             | [Project Config Guide](./project-config.md)                 |
 | `vite.config.ts` | Vite/Vitest config, uses `viteConfig` from `@faasjs/dev`                  | [Project Config Guide](./project-config.md)                 |
 
@@ -124,7 +124,7 @@ API routes map directly to file paths under `src/`. No routing registry needed.
 | `src/pages/todo/api/index.api.ts`   | `POST /pages/todo/api`       |
 | `src/pages/todo/api/default.api.ts` | Fallback for `/pages/todo/*` |
 
-See the [Routing Mapping Specification](../../../docs/specs/routing-mapping.md) for the full route resolution order.
+See the [Routing Mapping Specification](./routing-mapping.md) for the full route resolution order.
 
 ## Your First Feature
 
@@ -616,7 +616,7 @@ See the [defineApi Guide](./define-api.md) for detailed rules.
 
 ### Zero-Mapping routing
 
-API file paths map directly to request paths — no routing configuration needed. A file at `src/pages/todos/api/list.api.ts` responds to `POST /pages/todos/api/list`. See the [Routing Mapping Specification](../../../docs/specs/routing-mapping.md) for the full resolution order.
+API file paths map directly to request paths — no routing configuration needed. A file at `src/pages/todos/api/list.api.ts` responds to `POST /pages/todos/api/list`. See the [Routing Mapping Specification](./routing-mapping.md) for the full resolution order.
 
 ### `faas.yaml` configuration hierarchy
 
@@ -635,7 +635,7 @@ defaults:
           secure: false
 ```
 
-See the [faas.yaml Specification](../../../docs/specs/faas-yaml.md) for the full spec.
+See the [faas.yaml Specification](./faas-yaml.md) for the full spec.
 
 ### `@faasjs/ant-design` components
 
@@ -664,7 +664,7 @@ See the [React Data Fetching Guide](./react-data-fetching.md) for lifecycle cont
 
 Plugins inject cross-cutting concerns (auth, tenant context, request metadata) into the request lifecycle. They are configured in `faas.yaml` under the `plugins` key and can extend the `defineApi` handler context with typed fields.
 
-See the [Plugin Specification](../../../docs/specs/plugin.md) for plugin authoring.
+See the [Plugin Specification](./plugin.md) for plugin authoring.
 
 ## Development Workflow
 
@@ -726,7 +726,7 @@ Now that you have a working project, explore the detailed guides:
 | [Jobs Guide](./jobs.md)                                                 | Background jobs with `@faasjs/jobs`                          |
 | [Logger Guide](./logger.md)                                             | Logging patterns and log levels                              |
 | [Code Comments Guide](./code-comments.md)                               | JSDoc and comment conventions                                |
-| [faas.yaml Specification](../../../docs/specs/faas-yaml.md)             | Full faas.yaml configuration reference                       |
-| [Routing Mapping Specification](../../../docs/specs/routing-mapping.md) | Zero-Mapping route resolution                                |
-| [Plugin Specification](../../../docs/specs/plugin.md)                   | Plugin authoring and configuration                           |
-| [Http Protocol Specification](../../../docs/specs/http-protocol.md)     | HTTP request/response protocol details                       |
+| [faas.yaml Specification](./faas-yaml.md)             | Full faas.yaml configuration reference                       |
+| [Routing Mapping Specification](./routing-mapping.md) | Zero-Mapping route resolution                                |
+| [Plugin Specification](./plugin.md)                   | Plugin authoring and configuration                           |
+| [Http Protocol Specification](./http-protocol.md)     | HTTP request/response protocol details                       |

--- a/skills/faasjs-best-practices/guidelines/http-protocol.md
+++ b/skills/faasjs-best-practices/guidelines/http-protocol.md
@@ -1,0 +1,95 @@
+# HTTP Protocol Specification
+
+## Background
+
+FaasJS request/response guidance is spread across multiple locations. This spec defines a single internal baseline for transport behavior.
+
+## Goals
+
+- Keep client/server interaction predictable across projects.
+- Keep transport-level behavior aligned with current implementation, including low-level error fallback.
+- Keep failure semantics simple in V1.
+
+## Non-goals
+
+- Defining REST resource modeling patterns.
+- Defining GraphQL contracts.
+- Standardizing file upload and stream protocol details.
+
+## Normative Rules
+
+### 1. Request
+
+1. API requests MUST use `POST` as the default method.
+2. Request body MUST be encoded as JSON text (`application/json; charset=UTF-8`) and SHOULD be a JSON object.
+3. Query parameters SHOULD be avoided for business input; clients SHOULD send input in JSON body.
+4. Request path MUST follow [routing-mapping.md](./routing-mapping.md).
+5. Clients SHOULD include `X-FaasJS-Request-Id` for traceability when possible.
+
+### 2. Response (transport layer)
+
+1. The V1 status code baseline is `200`, `204`, and `500`.
+2. `200` means request completed with a response body, and payload MUST use top-level `data`.
+3. `204` means request completed with no content.
+4. Business failures MUST return `500` in the V1 baseline.
+5. For JSON error responses, payload MUST use top-level `error` with `error.message`.
+6. For low-level server failures, `500` MAY return plain text `Internal Server Error` with `Content-Type: text/plain; charset=utf-8`.
+7. JSON responses SHOULD use `Content-Type: application/json; charset=utf-8`.
+8. This specification is HTTP-version agnostic and does not require a specific HTTP protocol version.
+
+## Examples
+
+### Request
+
+```http
+POST /todo/api/create
+Content-Type: application/json; charset=UTF-8
+
+{"title":"Buy milk"}
+```
+
+### Response: 200 success
+
+```json
+{
+  "data": {
+    "id": 1,
+    "title": "Buy milk"
+  }
+}
+```
+
+### Response: 500 business/runtime error (JSON)
+
+```json
+{
+  "error": {
+    "message": "business-500"
+  }
+}
+```
+
+### Response: 500 low-level server error (plain text)
+
+```text
+500 Internal Server Error
+Content-Type: text/plain; charset=utf-8
+
+Internal Server Error
+```
+
+### Response: 500 transport/runtime error (JSON)
+
+```json
+{
+  "error": {
+    "message": "Internal Server Error"
+  }
+}
+```
+
+## Current Behavior Notes
+
+- Current runtime behavior is consistent with top-level `data`/`error` wrapping in `@faasjs/core`.
+- Current server fallback behavior can return plain-text `500 Internal Server Error` in low-level failures.
+- Existing projects may return additional status codes in custom logic. Those are outside this V1 baseline.

--- a/skills/faasjs-best-practices/guidelines/plugin.md
+++ b/skills/faasjs-best-practices/guidelines/plugin.md
@@ -1,0 +1,181 @@
+# Plugin Specification
+
+## Background
+
+FaasJS supports plugins in two complementary layers:
+
+- code registers plugin instances on `Func`
+- `faas.yaml` provides staged, directory-aware plugin configuration
+
+The runtime behavior is already stable across `@faasjs/core` and `@faasjs/node-utils`, but the contract is currently spread across source code, tests, and published docs.
+
+This specification defines the baseline for plugin identity, lifecycle execution, config layering, and config-driven loading.
+
+Related references:
+
+- `packages/core/src/func/index.ts`
+- `packages/core/src/index.ts`
+- `packages/node-utils/src/load_config.ts`
+- `packages/core/src/plugins/http/index.ts`
+- `docs/zh/guide/excel/plugin.md`
+
+## Goals
+
+- Keep plugin authoring and loading behavior predictable.
+- Define how plugin identity, ordering, config precedence, and deduplication work.
+- Make code registration and `faas.yaml` config play together without ambiguous ownership.
+- Align config-driven loading with current `defineApi()` behavior.
+
+## Non-goals
+
+- Defining each plugin package's private `config` schema.
+- Standardizing npm publishing, versioning, or marketplace metadata for plugins.
+
+## Normative Rules
+
+### 1. Runtime Plugin Contract
+
+1. A plugin instance MUST expose string `type` and string `name` fields.
+2. Plugin `name` MUST identify the runtime plugin id.
+3. Plugin `type` MUST identify the plugin source, family, or module specifier rather than the runtime instance id.
+4. Plugin `name` SHOULD stay stable within the same function because ordering, deduplication, logs, and config lookup rely on it.
+5. A plugin MAY implement `onMount`, `onInvoke`, or both.
+6. Plugins auto-loaded by `defineApi()` MUST be created from a constructor whose prototype implements at least one lifecycle method: `onMount` or `onInvoke`.
+7. Plugins registered in code MAY implement `applyConfig(resolvedConfig)` to receive the final merged config for their plugin id before first mount.
+
+### 2. Lifecycle Execution Model
+
+1. User plugins MUST execute before the built-in run-handler plugin.
+2. `onMount` hooks MUST run in plugin order and MUST run at most once per `Func` instance.
+3. `onInvoke` hooks MUST run in plugin order for every invocation.
+4. Plugins MUST use `await next()` to continue the lifecycle chain.
+5. Calling `next()` multiple times from the same lifecycle hook MUST reject with `next() called multiple times`.
+6. Plugins MAY mutate mount or invoke data to inject fields, prepare context, or control the final response.
+7. Errors thrown by a plugin or downstream handler MUST stop the current chain and propagate to the caller.
+
+### 3. Configuration Layering And Precedence
+
+1. Plugin configuration MAY be authored in code, in `faas.yaml`, or both.
+2. `faas.yaml` plugin config MUST support directory-level layering from project root toward the target API directory.
+3. When multiple `faas.yaml` files contribute config for the same plugin id, the deeper directory MUST override the shallower directory while preserving unspecified fields through deep merge.
+4. Code-authored plugin config MUST override merged `faas.yaml` config for the same plugin id.
+5. Plugin config merging MUST use plugin `name` as the identity key.
+6. Resolved plugin config exposed on `func.config.plugins` MUST reflect the final merged view after directory layering and code overrides.
+
+### 4. Manual Registration
+
+1. `new Func({ plugins: [...] })` MUST preserve the provided plugin order.
+2. Manual plugin arrays MUST NOT perform implicit deduplication; callers are responsible for avoiding duplicate plugin names when that matters.
+3. When code registers a plugin instance, that instance remains the source of runtime behavior; config resolution MAY augment its settings but MUST NOT silently replace it with another instance from YAML.
+4. When a pre-registered plugin instance implements `applyConfig`, the loader SHOULD call it with the final merged config for that plugin id.
+
+### 5. Config-Driven Loading In `defineApi()`
+
+1. `defineApi()` MUST resolve staged `faas.yaml` config and `func.config.plugins` before the first mount or invoke.
+2. The loader MUST inspect only own enumerable keys on `config.plugins`.
+3. Plugin config entries in `func.config.plugins` MUST be keyed by plugin id.
+4. For config-driven loading, resolved plugin `name` MUST default to the entry key and therefore represent the plugin id.
+5. For an object config entry, resolved plugin `type` MUST come from `type`, then fall back to the entry key only for built-in plugin ids explicitly supported by the runtime.
+6. The loader MUST instantiate plugins with the resolved config object plus resolved `name` and `type`.
+7. If a plugin with the same resolved `name` already exists on the function, config-driven loading MUST NOT create a duplicate runtime instance.
+8. When a plugin instance already exists in code and config exists for the same id, the resolved config MUST still be attached to `func.config.plugins[name]` with code values taking precedence.
+
+### 6. Module And Constructor Resolution
+
+1. Plugin type `http` MUST resolve to module `@faasjs/core`.
+2. Unscoped bare plugin types such as `mysql` MUST resolve to `@faasjs/<type>`.
+3. Scoped package names, relative paths, absolute paths, and `file://` local file URLs MUST resolve as authored after stripping an optional `npm:` prefix.
+4. When resolving a class export from a module, the loader MUST use normalized PascalCase class names derived from the plugin type or trailing path segments.
+5. If no matching named export is a valid lifecycle plugin constructor, the loader MUST throw an error.
+6. If constructor execution throws or returns a non-object plugin instance, the loader MUST throw an error.
+
+### 7. `defineApi()` Requirements
+
+1. A `defineApi()` function MUST have an `http` plugin available after plugin resolution.
+2. If the `http` plugin is missing, invocation MUST fail with an error that indicates the required `http` plugin is missing.
+3. Additional plugins MAY inject fields into the handler data by mutating invoke data before the business handler runs.
+4. Plugin packages that inject extra handler fields SHOULD provide TypeScript module augmentation for `DefineApiInject`.
+
+## Examples
+
+### Manual lifecycle plugin
+
+```ts
+import { Func, type InvokeData, type Next, type Plugin } from '@faasjs/core'
+
+class TracePlugin implements Plugin {
+  public readonly name = 'trace'
+  public readonly type = '@/plugins/trace'
+
+  public async onInvoke(data: InvokeData, next: Next) {
+    data.context.trace = ['before']
+    await next()
+    data.context.trace.push('after')
+  }
+}
+
+export default new Func({
+  plugins: [new TracePlugin()],
+  async handler({ context }) {
+    context.trace.push('handler')
+    return context.trace
+  },
+})
+```
+
+### Config layering with code precedence
+
+```yaml
+# src/faas.yaml
+defaults:
+  plugins:
+    auth:
+      type: file://./plugins/auth-plugin.ts
+      config:
+        provider: jwt
+        secret: from-root
+```
+
+```yaml
+# src/admin/faas.yaml
+defaults:
+  plugins:
+    auth:
+      config:
+        secret: from-admin
+```
+
+```ts
+import { defineApi } from '@faasjs/core'
+
+const api = defineApi({
+  async handler({ config, current_user }) {
+    return {
+      current_user,
+      auth: config.plugins?.auth,
+    }
+  },
+})
+
+api.config = {
+  plugins: {
+    auth: {
+      config: {
+        secret: 'from-code',
+      },
+    },
+    http: {
+      config: {},
+    },
+  },
+}
+
+export default api
+```
+
+In the resolved config:
+
+- plugin id is `auth`, so runtime `name === 'auth'`
+- plugin source comes from the configured `type`
+- `secret` resolves to `'from-code'`
+- `provider` remains `'jwt'`

--- a/skills/faasjs-best-practices/guidelines/routing-mapping.md
+++ b/skills/faasjs-best-practices/guidelines/routing-mapping.md
@@ -1,0 +1,76 @@
+# Routing Mapping Specification
+
+## Background
+
+FaasJS API route resolution is file-based. This spec standardizes backend route
+mapping so Zero-Mapping remains explicit: file path and request path stay in
+one-to-one alignment by default.
+
+Frontend page components may still live under `src/pages`, but FaasJS does not
+auto-discover webpage routes for React applications anymore. Browser routing is
+an application concern and is out of scope for this spec.
+
+Related references:
+
+- `packages/core/src/server/routes.ts`
+- `packages/core/src/server/routes.test.ts`
+- `documents/projects/faasjs/rfc-spa-api-zero-mapping-v0.1-short.md`
+
+## Goals
+
+- Keep API locations discoverable from the request path without an extra mapping table.
+- Reduce ambiguity for humans and AI coding agents.
+- Keep backend route search order predictable.
+
+## Non-goals
+
+- Introducing path aliases or rewrite layers.
+- Replacing file-system routing with a registry-based router.
+- Adding dynamic filename segments such as `[id]` or `[...slug]` in this V1 spec.
+- Defining browser routing or SPA page discovery behavior.
+
+## Normative Rules
+
+### 1. File naming and placement
+
+1. API entry files MUST end with `.api.ts`.
+2. API files SHOULD be placed under `api/` directories for SPA-style projects.
+3. API files MUST NOT be placed under `components/` directories.
+4. Files other than `*.api.ts` MUST NOT create API routes implicitly.
+
+### 2. Zero-mapping routing
+
+1. Request path and file path MUST keep direct mapping (Zero-Mapping by default).
+2. API routes MUST map from the full path under `src/`; implementations MUST NOT rely on implicit rewrites such as `actions -> api`.
+3. Implementations MUST NOT add hidden alias routes that break path/file predictability.
+
+### 3. API route file search order
+
+Given API request path `<p>`, route resolution MUST probe in this order:
+
+1. `<p>.api.ts`
+2. `<p>/index.api.ts`
+3. `<p>/default.api.ts`
+4. Parent fallback chain: `<parent>/default.api.ts` up to root scope
+
+If no candidate exists, the request is treated as not found.
+
+## Examples
+
+| File                              | Route                                          |
+| --------------------------------- | ---------------------------------------------- |
+| `src/pages/todo/api/list.api.ts`  | `POST /pages/todo/api/list`                    |
+| `src/pages/todo/api/index.api.ts` | `POST /pages/todo/api`                         |
+| `src/pages/todo/default.api.ts`   | fallback for `/pages/todo/*`                   |
+| `src/pages/default.api.ts`        | fallback for unmatched routes under `/pages/*` |
+
+API fallback example:
+
+- Request: `POST /pages/todo/item/unknown`
+- Probe order:
+  1. `src/pages/todo/item/unknown.api.ts`
+  2. `src/pages/todo/item/unknown/index.api.ts`
+  3. `src/pages/todo/item/unknown/default.api.ts`
+  4. `src/pages/todo/item/default.api.ts`
+  5. `src/pages/todo/default.api.ts`
+  6. `src/pages/default.api.ts`


### PR DESCRIPTION
## 背景

skills 文件夹下的 `faasjs-best-practices/guidelines/` 中有 3 个文件引用了技能文件夹外部的文档（`../../../docs/specs/*.md`），不符合"所有链接都在当前技能文件夹内"的规范。

## 变更

- 新增 4 个子文档：将 `docs/specs/` 下的 4 个 spec 文件复制到 `guidelines/` 目录
  - `routing-mapping.md`
  - `faas-yaml.md`
  - `plugin.md`
  - `http-protocol.md`
- 修改 3 个文件中的 11 处外部链接为 `./` 相对路径
  - `file-conventions.md`：1 处
  - `getting-started.md`：9 处
  - `cli-and-tooling.md`：2 处

## 验证

- 搜索 `../../` 模式：0 结果
- 所有 `./xxx.md` 链接目标文件均存在

## 风险

无破坏性变更，仅将外部引用内化为技能文件夹子文档。
